### PR TITLE
Initial update of Roslyn satellites for 15.5

### DIFF
--- a/build/UpdateResources.proj
+++ b/build/UpdateResources.proj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <FSharpSatelliteDirectory>\\cpvsbuild\drops\FSharp\Microbuild\20170726.1\Binaries\coreclr\bin\localize\</FSharpSatelliteDirectory>
-    <RoslynSatelliteDirectory>\\cpvsbuild\drops\VS\d15rel\raw\current\binaries.x86ret\Localized\simship\</RoslynSatelliteDirectory>
+    <RoslynSatelliteDirectory>\\cpvsbuild\drops\VS\d15rel\raw\26927.01\binaries.x86ret\Localized\simship\</RoslynSatelliteDirectory>
     <IntermediateOutputPath>..\bin\Intermediate\</IntermediateOutputPath>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -42,7 +42,7 @@
     <Authors>Microsoft Corporation</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <BuildEpoch>20170101</BuildEpoch>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionPrefix Condition="$(IsFSharp)">4.4.1</VersionPrefix>
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
     <BuildNumber Condition="'$(BuildNumber)' == ''">99999999-99</BuildNumber>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.cs.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.cs.resx
@@ -380,6 +380,9 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>Jenom členy kompatibilní se specifikací CLS můžou být abstraktní.</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>Sestavení a modul {0} nemůžou mířit na různé procesory.</value>
   </data>
@@ -468,7 +471,7 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
     <value>{0} neimplementuje vzorek {1}. {2} je nejednoznačný vzhledem k: {3}.</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>Neplatná možnost {0} pro /langversion; musí být ISO-1, ISO-2, Default, Latest nebo platná verze v rozsahu 1 až 7.1.</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>Název kvalifikovaný pomocí aliasu není výraz.</value>
@@ -713,6 +716,9 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>Konstanta s pohyblivou řádovou čárkou je mimo rozsah typu {0}.</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>Nejde vygenerovat ladicí informace pro zdrojový text bez kódování.</value>
   </data>
@@ -733,6 +739,9 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>Očekávala se koncová značka pro element {0}.</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>Argumenty typů nejsou v operátoru nameof povoleny.</value>
@@ -872,11 +881,14 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>Typ {0} ze sestavení {1} se nedá použít přes hranice sestavení, protože má argument obecného typu, který je vloženým definičním typem.</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>Operátor as je třeba použít s typem odkazu nebo s typem připouštějícím hodnotu null ({0} je typ hodnoty, který nepřipouští hodnotu null).</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>Metodu abstract {0} nejde označit jako virtuální.</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>{0}: Statické třídy nemůžou obsahovat operátory definované uživatelem.</value>
@@ -1028,6 +1040,9 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>Výraz filtru je konstanta. Zvažte odebrání filtru.</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>Funkce {0} není dostupná v jazyce C# 7.1. Použijte prosím jazyk verze {1} nebo vyšší.</value>
   </data>
@@ -1109,6 +1124,9 @@ Potlačení upozornění zvažte jenom v případě, když určitě nechcete če
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>Člen {0} neskrývá přístupný člen. Klíčové slovo new se nevyžaduje.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>Číslo, které bylo předané do direktivy preprocesoru varování #pragma, nepředstavovalo platné číslo varování. Ověřte, že číslo představuje varování, ne chybu.</value>
   </data>
@@ -1126,6 +1144,9 @@ Potlačení upozornění zvažte jenom v případě, když určitě nechcete če
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>#r je povolený jenom ve skriptech.</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>Strom syntaxe už je přítomný.</value>
@@ -1322,6 +1343,9 @@ Potlačení upozornění zvažte jenom v případě, když určitě nechcete če
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>Neplatný parametr aliasu odkazu: {0}= – nenašel se název souboru.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>Členy pole jen pro čtení {0} nejde vrátit odkazem.</value>
   </data>
@@ -1347,7 +1371,7 @@ Potlačení upozornění zvažte jenom v případě, když určitě nechcete če
     <value>Událost Windows Runtimu se nesmí předat jako parametr out nebo ref.</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>Instance typu {0} se nedá použít v anonymní funkci, výrazu dotazu, bloku iterátoru nebo asynchronní metodě.</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>{0} neimplementuje člen rozhraní {1}. {2} nemůže implementovat člen {1}, protože nemá odpovídající návratový typ {3}.</value>
@@ -1828,7 +1852,7 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
     <value>Operandem operátoru přičtení nebo odečtení musí být proměnná, vlastnost nebo indexer.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Přepínač /embed se podporuje jenom při generování souboru PDB typu Portable (/debug:portable nebo /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>{0} nemůže být extern i abstract.</value>
@@ -3111,8 +3135,8 @@ Pokud se taková třída používá jako základní třída a pokud odvozující
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>Došlo k nejednoznačnosti mezi metodami nebo vlastnostmi {0} a {1}.</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>Jako částečné jde deklarovat jenom metody, třídy, struktury a rozhraní.</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>Chyba syntaxe příkazového řádku: Chybí GUID pro možnost {1}.</value>
@@ -3191,143 +3215,146 @@ Pokud se taková třída používá jako základní třída a pokud odvozující
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Možnosti kompilátoru Visual C#
+                              Visual C# Compiler Options
 
-                        – VÝSTUPNÍ SOUBORY –
- /out:&lt;soubor&gt;                   Určuje název výstupního souboru (výchozí: základní název
-                               souboru s hlavní třídou nebo prvního souboru).
- /target:exe                   Vytvoří spustitelný soubor konzoly (výchozí). 
-                               (Krátký tvar: /t:exe)
- /target:winexe                Vytvoří spustitelný soubor Windows. (Krátký tvar: 
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               Vytvoří knihovnu. (Krátký tvar: /t:library)
- /target:module                Vytvoří modul, který se dá přidat do jiného 
-                               sestavení. (Krátký tvar: /t:module)
- /target:appcontainerexe       Vytvoří spustitelný soubor kontejneru Appcontainer. (Krátký tvar: 
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              Vytvoří pomocný soubor modulu Windows Runtime, který 
-                               využívá knihovna WinMDExp. (Krátký tvar: /t:winmdobj)
- /doc:&lt;soubor&gt;                   Soubor dokumentace XML, který se má generovat.
- /refout:&lt;file&gt;                Výstup referenčního sestavení, který se bude generovat
- /platform:&lt;řetězec&gt;            Omezuje platformy, na kterých se dá tento kód spustit: x86,
-                               Itanium, x64, arm, anycpu32bitpreferred nebo 
-                               anycpu. Výchozí je anycpu.
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        – VSTUPNÍ SOUBORY–
- /recurse:&lt;zástupný znak&gt;           Zahrne všechny soubory v aktuálním adresáři 
-                               a podadresářích podle zadaného 
-                               zástupného znaku.
- /reference:&lt;alias&gt;=&lt;soubor&gt;     Odkazuje na metadata ze zadaného souboru 
-                               sestavení pomocí daného aliasu. (Krátký tvar: /r)
- /reference:&lt;seznam souborů&gt;        Odkazuje na metadata ze zadaných souborů 
-                               sestavení. (Krátký tvar: /r)
- /addmodule:&lt;seznam souborů&gt;        Připojí zadané moduly do tohoto sestavení.
- /link:&lt;seznam souborů&gt;             Vloží metadata ze zadaných souborů 
-                               definičních sestavení. (Krátký tvar: /l)
- /analyzer:&lt;seznam souborů&gt;         Spustí analyzátory z tohoto sestavení.
-                               (Krátký tvar: /a)
- /additionalfile:&lt;seznam souborů&gt;   Další soubory, které přímo neovlivňují generování
-                               kódu, ale analyzátory můžou jejich pomocí
-                               produkovat chyby nebo upozornění.
- /embed                        Vloží všechny zdrojové soubory do PDB.
- /embed:&lt;seznam souborů&gt;            Vloží konkrétní soubory do PDB.
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        – PROSTŘEDKY –
- /win32res:&lt;soubor&gt;              Určuje soubor prostředků Win32 (.res).
- /win32icon:&lt;soubor&gt;             Použije pro výstup zadanou ikonu.
- /win32manifest:&lt;soubor&gt;         Určuje soubor manifestu Win32 (.xml).
- /nowin32manifest              Nezahrne výchozí manifest Win32.
- /resource:&lt;resinfo&gt;           Vloží zadaný prostředek. (Krátký tvar: /res)
- /linkresource:&lt;resinfo&gt;       Propojí zadaný prostředek s tímto sestavením. 
-                               (Krátký tvar: /linkres) Prostředek má formát 
-                               &lt;soubor&gt;[,&lt;název řetězce&gt;[,public|private]].
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        – GENEROVÁNÍ KÓDU –
- /debug[+|-]                   Generuje ladicí informace.
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               Určuje typ ladění (výchozí je možnost full, 
-                               portable je formát napříč platformami,
-                               embedded je formát napříč platformami vložený do 
-                               cílového souboru .dll nebo .exe).
- /optimize[+|-]                Povolí optimalizace. (Krátký tvar: /o)
- /deterministic                Vytvoří deterministické sestavení
-                               (včetně GUID verze modulu a časového razítka).
- /refonly                      Vytvoří referenční sestavení na místě hlavního výstupu.
- /instrument:TestCoverage      Vytvoří sestavení instrumentované ke shromažďování
-                               informací o pokrytí.
- /sourcelink:&lt;soubor&gt;            Informace o zdrojovém odkazu vkládané do souboru PDB typu Portable.
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        – CHYBY A UPOZORNĚNÍ –
- /warnaserror[+|-]             Hlásí všechna upozornění jako chyby.
- /warnaserror[+|-]:&lt;seznam upozornění&gt; Hlásí zadaná upozornění jako chyby.
- /warn:&lt;n&gt;                     Nastaví úroveň pro upozornění (0–4). (Krátký tvar: /w)
- /nowarn:&lt;seznam upozornění&gt;           Zakáže zadaná upozornění.
- /ruleset:&lt;soubor&gt;               Určuje soubor sady pravidel, která zakazuje
-                               specifickou diagnostiku.
- /errorlog:&lt;soubor&gt;              Určuje soubor pro protokolování veškeré
-                               diagnostiky kompilátoru a analyzátoru.
- /reportanalyzer               Hlásí další informace analyzátoru, např.
-                               dobu spuštění.
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        – JAZYK –
- /checked[+|-]                 Generuje kontroly přetečení.
- /unsafe[+|-]                  Povoluje nezabezpečený kód.
- /define:&lt;seznam symbolů&gt;         Definuje symboly podmíněné kompilace. (Krátký 
-                               tvar: /d)
- /langversion:&lt;řetězec&gt;         Určuje režim jazykové verze: ISO-1, ISO-2, 3, 
-                               4, 5, 6, 7, 7.1, Default (Výchozí) nebo Latest (Nejnovější).
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        – ZABEZPEČENÍ –
- /delaysign[+|-]               Vytvoří zpožděný podpis sestavení s využitím 
-                               veřejné části klíče silného názvu.
- /publicsign[+|-]              Vytvoří veřejný podpis sestavení s využitím jenom veřejné
-                               části klíče silného názvu.
- /keyfile:&lt;soubor&gt;               Určuje soubor klíče se silným názvem.
- /keycontainer:&lt;řetězec&gt;        Určuje kontejner klíče se silným názvem.
- /highentropyva[+|-]           Povolí ASLR s vysokou entropií.
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        – RŮZNÉ –
- @&lt;soubor&gt;                       Načte další možnosti ze souboru odpovědí.
- /help                         Zobrazí tuto zprávu o použití. (Krátký tvar: /?)
- /nologo                       Potlačí zprávu o autorských právech kompilátoru.
- /noconfig                     Nezahrnuje automaticky soubor CSC.RSP.
- /parallel[+|-]                Souběžné sestavení 
- /version                      Zobrazí číslo verze kompilátoru a ukončí se.
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
 
-                        – POKROČILÉ –
- /baseaddress:&lt;adresa&gt;        Základní adresa pro knihovnu, která se má sestavit
- /checksumalgorithm:&lt;alg&gt;      Určuje algoritmus pro výpočet kontrolního součtu 
-                               zdrojového souboru uloženého v PDB. Podporované hodnoty:
-                               SHA1 (výchozí) nebo SHA256.
- /codepage:&lt;n&gt;                 Určuje znakovou stránku, která se má použít 
-                               při otevírání zdrojových souborů.
- /utf8output                   Určuje výstup zpráv kompilátoru v kódování UTF-8.
- /main:&lt;typ&gt;                  Určuje typ obsahující vstupní bod (ignoruje 
-                               všechny ostatní potenciální vstupní body). (Krátký 
-                               tvar: /m)
- /fullpaths                    Kompilátor generuje úplné cesty.
- /filealign:&lt;n&gt;                Určuje zarovnání použité pro oddíly výstupního 
-                               souboru.
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
  /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                               Určuje mapování pro výstup zdrojových názvů cest
-                               kompilátorem.
- /pdb:&lt;soubor&gt;                   Určuje název souboru ladicích informací (výchozí: 
-                               název výstupního souboru s příponou .pdb).
- /errorendlocation             Vypíše řádek a sloupec koncového umístění 
-                               jednotlivých chyb.
- /preferreduilang              Určuje název upřednostňovaného výstupního jazyka.
- /nostdlib[+|-]                Neodkazuje na standardní knihovnu (mscorlib.dll).
- /subsystemversion:&lt;řetězec&gt;    Určuje verzi subsystému tohoto sestavení.
- /lib:&lt;seznam souborů&gt;              Určuje další adresáře, ve kterých se mají 
-                               hledat reference.
- /errorreport:&lt;řetězec&gt;         Určuje způsob zpracování interních chyb kompilátoru: 
-                               prompt, send, queue nebo none. Výchozí možnost 
-                               je queue (zařadit do fronty).
- /appconfig:&lt;soubor&gt;             Určuje konfigurační soubor aplikace, 
-                               který obsahuje nastavení vazby sestavení.
- /moduleassemblyname:&lt;řetězec&gt;  Určuje název sestavení, jehož součástí bude 
-                               tento modul.
- /modulename:&lt;řetězec&gt;          Určuje název zdrojového modulu.
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
+                               queue.
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3637,7 +3664,7 @@ Pokud se taková třída používá jako základní třída a pokud odvozující
     <value>CallerMemberNameAttribute nejde použít, protože neexistuje žádný standardní převod z typu {0} na {1}.</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>Člen pro parametr {0} nejde vrátit odkazem, protože nejde o parametr Ref nebo Out.</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(Umístění symbolu vzhledem k předchozí chybě)</value>
@@ -3682,7 +3709,7 @@ Pokud se taková třída používá jako základní třída a pokud odvozující
     <value>Parametr nejde vrátit odkazem {0}, protože nejde o parametr Ref nebo Out.</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>Prvky definované v oboru názvů nejde explicitně deklarovat jako privátní, chráněné nebo interní chráněné.</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>Parametr /moduleassemblyname jde zadat jenom při vytváření typu cíle module.</value>
@@ -3851,6 +3878,9 @@ Pokud se taková třída používá jako základní třída a pokud odvozující
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>{0} definuje operátor == nebo !=, ale nepřepisuje funkci Object.GetHashCode().</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>Jeden z parametrů binárního operátoru musí být nadřazeného typu.</value>
@@ -4315,7 +4345,7 @@ Pokud se taková třída používá jako základní třída a pokud odvozující
     <value>Parametr typu {1} má omezení struct, takže není možné používat {1} jako omezení pro {0}.</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>Předdefinovaný typ {0} není nadefinovaný ani naimportovaný.</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>Argument typu nemůže být null.</value>
@@ -4480,7 +4510,7 @@ Pokud se taková třída používá jako základní třída a pokud odvozující
     <value>Argument {0}: Nejde převést z {1} na {2}.</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>Specifikace pojmenovaných argumentů musí následovat po specifikaci všech pevných argumentů</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>Omezení pro parametr typu {0} metody {1} se musí shodovat s omezeními u parametru typu {2} metody rozhraní {3}. Místo toho zvažte použití explicitní implementace rozhraní.</value>
@@ -5060,6 +5090,9 @@ Pokud se taková třída používá jako základní třída a pokud odvozující
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>indexer s výrazem v těle</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>{0}: Nejde odvozovat z dynamického typu.</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.de.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.de.resx
@@ -380,6 +380,9 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>Nur CLS-kompatible Elemente können abstrakt sein</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>Die Assembly und das Modul "{0}" können nicht verschiedene Zielprozessoren haben.</value>
   </data>
@@ -468,7 +471,7 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
     <value>"{0}" implementiert das Muster "{1}" nicht. "{2}" ist mit "{3}" nicht eindeutig.</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>Ungültige Option "{0}" für "/langversion". Zulässige Optionen sind "ISO-1", "ISO-2", "Default", "Latest" oder eine gültige Version zwischen 1 und 7.1.</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>Ein aliasqualifizierter Name ist kein Ausdruck.</value>
@@ -713,6 +716,9 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>Die Gleitkommakonstante liegt außerhalb des Bereichs von Typ "{0}".</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>Debuginformationen für einen Quelltext können nur codiert ausgegeben werden.</value>
   </data>
@@ -733,6 +739,9 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>Eine Endkennung für Element "{0}" wurde erwartet.</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>Typargumente sind im nameof-Operator unzulässig.</value>
@@ -872,11 +881,14 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>Der Typ "{0}" aus der Assembly "{1}" kann nichtüber Assemblygrenzen hinweg verwendet werden, da er ein generisches Typargument besitzt, bei dem es sich um einen eingebetteten Interoptyp handelt.</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>Der as-Operator muss mit einem Referenztyp oder einem Typ, der NULL-Werte zulässt, verwendet werden. ("{0}" ist ein Werttyp, der keine NULL-Werte zulässt.)</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>Die abstrakte Methode "{0}" kann nicht als virtuell markiert werden.</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>"{0}": Statische Klassen können keine benutzerdefinierten Operatoren enthalten.</value>
@@ -1028,6 +1040,9 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>Der Filterausdruck ist eine Konstante. Sie sollte den Filter entfernen.</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>Das Feature "{0}" ist in C# 7.1 nicht verfügbar. Verwenden Sie die Sprachversion {1} oder höher.</value>
   </data>
@@ -1109,6 +1124,9 @@ Sie sollten das Unterdrücken der Warnung nur in Betracht ziehen, wenn Sie siche
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>Das Mitglied "{0}" blendet kein verfügbares Mitglied aus. Das neue Schlüsselwort ist nicht erforderlich.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>Eine Zahl, die an die Präprozessordirektive der #pragma-Warnung übergeben wurde, war keine gültige Warnungszahl. Vergewissern Sie sich, dass die Zahl eine Warnung und keinen Fehler darstellt.</value>
   </data>
@@ -1126,6 +1144,9 @@ Sie sollten das Unterdrücken der Warnung nur in Betracht ziehen, wenn Sie siche
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>#r ist nur in Skripts zulässig.</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>Der Syntaxbaum ist bereits vorhanden.</value>
@@ -1322,6 +1343,9 @@ Sie sollten das Unterdrücken der Warnung nur in Betracht ziehen, wenn Sie siche
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>Ungültige Verweisaliasoption: "{0}=". Fehlender Dateiname.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>Member des schreibgeschützten Felds "{0}" können nicht als Verweis zurückgegeben werden.</value>
   </data>
@@ -1347,7 +1371,7 @@ Sie sollten das Unterdrücken der Warnung nur in Betracht ziehen, wenn Sie siche
     <value>Ein Windows-Runtime-Ereignis darf nicht als out- oder ref-Parameter übergeben werden.</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>Eine Instanz des Typs "{0}" kann nicht in einer anonymen Funktion, einem Abfrageausdruck, einem Iteratorblock oder einer Async-Methode verwendet werden.</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>"{0}" implementiert den Schnittstellenmember "{1}" nicht. "{2}" hat nicht den entsprechenden Rückgabetyp "{3}" und kann "{1}" daher nicht implementieren.</value>
@@ -1828,7 +1852,7 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
     <value>Der Operand eines Inkrement- oder Dekrementoperators muss eine Variable, eine Eigenschaft oder ein Indexer sein.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Der Schalter "/embed" wird nur unterstützt, wenn portable PDB-Dateien ausgegeben werden ("/debug:portable" oder "/debug:embedded").</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>"{0}" kann nicht gleichzeitig extern und abstrakt sein.</value>
@@ -3111,8 +3135,8 @@ Wenn solch eine Klasse als Basisklasse verwendet wird und die ableitende Klasse 
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>Mehrdeutigkeit zwischen "{0}" und "{1}"</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>Nur Methoden, Klassen, Strukturen oder Schnittstellen können partiell sein.</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>Befehlszeilen-Syntaxfehler: Fehlende GUID für Option "{1}".</value>
@@ -3191,143 +3215,146 @@ Wenn solch eine Klasse als Basisklasse verwendet wird und die ableitende Klasse 
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Visual C#-Compileroptionen 
+                              Visual C# Compiler Options
 
-                        - AUSGABEDATEIEN -
- /out:&lt; Datei &gt;                   Gibt den Namen der Ausgabedatei an (Standardeinstellung: Basisname der
-                               Datei mit der Hauptklasse oder der ersten Datei)
- /target:exe                   Erstellt eine ausführbare Konsolendatei (Standardeinstellung) (Kurzform:
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
                                form: /t:exe)
- /target:winexe                winexe                Erstellt eine ausführbare Windows-Datei (Kurzform:
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               Erstellt eine Bibliothek (Kurzform: /t:library)
- /target:module                Erstellt ein Modul, das einer anderen Assembly
-                               hinzugefügt werden kann (Kurzform: /t:module)
- /target:appcontainerexe       Erstellt eine ausführbare App-Containerdatei (Kurzform:
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              Erstellt eine temporäre Windows-Runtime-Zwischendatei, die
-                               von WinMDExp verwendet wird (Kurzform: /t:winmdobj)
- /doc:&lt; Datei &gt;                   Die zu generierende XML-Dokumentationsdatei
- /refout:&lt;Datei&gt;                Die zu generierende Referenzverweisausgabe
- /platform:&lt; Zeichenfolge &gt;            Schränkt ein, auf welchen Plattformen dieser Code ausgeführt werden kann: x86,
-                               Itanium, x64, arm, anycpu32bitpreferred oder
-                               anycpu. Die Standardeinstellung ist "anycpu".
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        - EINGABEDATEIEN -
- /recurse:&lt; Platzhalter &gt;           Schließt alle Dateien im aktuellen Verzeichnis und
-                               in Unterverzeichnissen gemäß Platzhalter-
-                               spezifikationen ein 
- /reference:&lt;Alias&gt;=&lt;Datei&gt;     Verweist auf Metadaten aus der angegebenen Assembly-
-                               datei mithilfe eines angegebenen Alias (Kurzform: /r)
- /reference:&lt;Dateiliste&gt;        Verweist aus Metadaten der angegebenen Assembly-
-                               dateien (Kurzform: /r)
- /addmodule:&lt;Dateiliste&gt;        Verknüpft die angegebenen Module in dieser Assembly.
- /link:&lt;Dateiliste&gt;             Bettet Metadaten der angegebenen Interop-
-                               assemblydateien ein (Kurzform: /l)
- /analyzer:&lt; Dateiliste &gt;         Führt die Analyse aus dieser Assembly aus.
-                               (Kurzform: /a)
- /additionalfile:&lt; Dateiliste &gt;   Zusätzliche Dateien, die sich nicht direkt auf die Code-
-                               generierung auswirken, aber von der Analyse zum Erzeugen von
-                               Fehlern oder Warnungen verwendet werden können.
- /embed                        Bettet alle Quelldateien in die PDB-Datei ein.
- /embed:&lt;Dateiliste&gt;            Bettet bestimmte Dateien in die PDB-Datei ein.
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        - RESSOURCEN -
- /win32res:&lt;Datei&gt;              Gibt eine Win32-Ressourcendatei (RES-Datei) an.
- /win32icon:&lt;Datei&gt;             Verwendet dieses Symbol für die Ausgabe.
- /win32manifest:&lt;Datei&gt;         Gibt eine Win32-Manifestdatei (XML-Datei) an.
- /nowin32manifest              Schließt das Win32-Standardmanifest nicht ein.
- /resource:&lt;resinfo&gt;           Bettet die angegebene Ressource ein (Kurzform: /res)
- /linkresource:&lt;resinfo&gt;       Verknüpft die angegebene Ressource mit dieser Assembly
-                               (Kurzform: /linkres). Dabei ist das ResInfo-Format
-                               &lt;Datei&gt;[,&lt;Zeichenfolgenname&gt;[,public|private]]
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        - CODEGENERIERUNG -
- /debug[+|-]                   Gibt Debuginformationen aus 
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               Gibt den Debugtyp an ("full" ist der Standardwert,
-                               "portable" ist ein plattformübergreifendes Format,
-                               "embedded" ist ein plattformübergreifendes Format, das in die
-                               Ziel-DLL oder -EXE eingebettet ist).
- /optimize[+|-]                Aktiviert Optimierungen (Kurzform: /o)
- /deterministic                Generiert eine deterministische Assembly 
-                               (einschließlich Modulversion-GUID und Zeitstempel)
- /refonly                      Erstellt eine Referenzassembly anstelle der Hauptausgabe.
- /instrument:TestCoverage      Generiert eine Assembly, die für die
-                               Erfassung von Code Coverage-Informationen instrumentiert ist.
- /sourcelink:&lt;Datei&gt;            Quelllinkinformationen zum Einbetten in portable PDB-Dateien.
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        - FEHLER UND WARNUNGEN -
- /warnaserror[+|-]             Meldet alle Warnungen als Fehler.
- /warnaserror[+|-]:&lt;Warnungsliste&gt; Meldet bestimmte Warnungen als Fehler.
- /warn:&lt;n&gt;                     Legt die Warnstufe fest (0–4) (Kurzform: /w)
- /nowarn:&lt; Warnungsliste &gt;           Deaktiviert bestimmte Warnmeldungen.
- /ruleset:&lt;Datei&gt;               Gibt eine Rulesetdatei an, die bestimmte Diagnosevorgänge
-                               deaktiviert.
- /errorlog:&lt;Datei&gt;              Gibt eine Datei zur Protokollierung aller Diagnosevorgänge von Compiler und
-                               Analyzer an.
- /reportanalyzer               Berichtet zusätzliche Analyseinformationen wie etwa die
-                               Ausführungszeit.
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        - SPRACHE -
- /checked[+|-]                 Generiert Überlaufüberprüfungen
- /unsafe[+|-]                  Lässt "unsicheren" Code zu.
- /define:&lt;Symbolliste&gt;         Definiert bedingte Kompilationssymbole (Kurz-
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
                                form: /d)
- /langversion:&lt;Zeichenfolge&gt;         Gibt den Sprachversionsmodus an: ISO-1, ISO-2, 3,
-                               4, 5, 6, 7, 7.1, Standard oder Aktuell
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        - SICHERHEIT -
- /delaysign[+|-]               Signiert die Assembly verzögert nur mit dem öffentlichen
-                               Teil des starken Namensschlüssels.
- /publicsign[+|-]              Signiert die Assembly öffentlich nur mit dem öffentlichen
-                               Teil des starken Namensschlüssels.
- /keyfile:&lt;Datei&gt;               Gibt eine Datei für den starken Namensschlüssel an.
- /keycontainer:&lt;Zeichenfolge&gt;        Gibt einen Container für den starken Namensschlüssel an.
- /highentropyva[+|-]           Aktiviert ASLR mit hoher Entropie.
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        - VERSCHIEDENES -
- @&lt;Datei&gt;                       Weitere Optionen finden Sie in der Antwortdatei.
- /help                         Zeigt diese Syntaxmeldung an (Kurzform: /?)
- /nologo                       Unterdrückt die Copyrightmeldung des Compilers.
- /noconfig                     Schließt die CSC.RSP-Datei nicht automatisch ein.
- /parallel[+|-]                Gleichzeitige Erstellung.
- /version                      Zeigt die Compilerversionsnummer und die Beendigung an.
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
 
-                        - ERWEITERT -
- /baseaddress:&lt;Adresse&gt;        Die Basisadresse für die zu erstellende Bibliothek.
- /checksumalgorithm:&lt;alg&gt;      Gibt einen Algorithmus für das Berechnen der Quelldatei-
-                               prüfsumme an, die in der PDB-Datei gespeichert ist. Unterstützte Werte sind:
-                               SHA1 (Standard) oder SHA256.
- /codepage:&lt;n&gt;                 Gibt die beim Öffnen von Quelldateien zu verwendende
-                               Codepage an.
- /utf8output                   Ausgabecompilermeldungen in UTF-8-Codierung
- /main:&lt;Typ&gt;                  Gibt den Typ an, der den Einstiegspunkt enthält
-                               (alle anderen möglichen Einstiegspunkte werden ignoriert) (Kurz-
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
                                form: /m)
- /fullpaths                    Der Compiler generiert vollqualifizierte Pfade.
- /filealign:&lt;n&gt;                Gibt die Ausrichtung an, die für Ausgabedateiabschnitte
-                               verwendet werden soll.
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
  /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                               Gibt eine Zuordnung für die Quellpfadnamen an, die vom 
-                               the Compiler ausgegeben werden.
- /pdb:&lt;Datei&gt;                   Gibt den Namen der Debuginformationsdatei an (Standard:
-                               Ausgabedateiname mit der Erweiterung .pdb)
- /errorendlocation             Die Ausgabezeile und -spalte des Endpunkts
-                               jedes Fehlers 
- /preferreduilang              Gibt den bevorzugten Namen der Ausgabesprache an.
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
  /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
- /subsystemversion:&lt;Zeichenfolge&gt;    Verweist nicht auf die Standardbibliothek 
- /lib:&lt;Dateiliste&gt;              Gibt zusätzliche Verzeichnisse an, in denen nach Verweisen
-                               gesucht werden soll.
- /errorreport:&lt;Zeichenfolge&gt;         Gibt die Verarbeitung interner Compilerfehler an:
-                               "prompt", "send", "queue" oder "none". Der Standardwert ist
-                               "queue".
- /appconfig:&lt;Datei&gt;             Gibt eine Anwendungskonfigurationsdatei
-                               mit Assemblybindungseinstellungen an.
- /moduleassemblyname:&lt;Zeichenfolge&gt;  Der Name der Assembly, zu der dieses Modul
-                               gehören wird .
- /modulename:&lt;Zeichenfolge&gt;          Gibt den Quellmodulnamen an.
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
+                               queue.
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3637,7 +3664,7 @@ Wenn solch eine Klasse als Basisklasse verwendet wird und die ableitende Klasse 
     <value>CallerMemberNameAttribute kann nicht angewendet werden, da keine Standardkonvertierungen von Typ "{0}" in Typ "{1}" verfügbar sind.</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>Ein Member des Parameters "{0}" kann nicht als Verweis zurückgegeben werden, weil es sich nicht um einen ref- oder out-Parameter handelt.</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(Position des Symbols für den vorherigen Fehler)</value>
@@ -3682,7 +3709,7 @@ Wenn solch eine Klasse als Basisklasse verwendet wird und die ableitende Klasse 
     <value>Ein Parameter kann nicht als Verweis "{0}" zurückgegeben werden, weil es sich nicht um einen ref- oder out-Parameter handelt.</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>Die in einem Namespace definierten Elemente dürfen nicht explizit als "private", "protected" oder "protected internal" deklariert werden.</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>Die Option /moduleassemblyname kann nur beim Erstellen des Zieltyps "module" angegeben werden.</value>
@@ -3851,6 +3878,9 @@ Wenn solch eine Klasse als Basisklasse verwendet wird und die ableitende Klasse 
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>"{0}" definiert den Operator == oder !=, aber überschreibt Object.GetHashCode() nicht.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>Einer der Parameter eines binären Operators muss der enthaltende Typ sein.</value>
@@ -4315,7 +4345,7 @@ Wenn solch eine Klasse als Basisklasse verwendet wird und die ableitende Klasse 
     <value>Der {1}-Typparameter enthält die Einschränkung "struct". "{1}" kann daher nicht als Einschränkung für "{0}" verwendet werden.</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>Der vordefinierte Typ "{0}" ist nicht definiert oder importiert.</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>Das Typargument kann nicht NULL sein.</value>
@@ -4480,7 +4510,7 @@ Wenn solch eine Klasse als Basisklasse verwendet wird und die ableitende Klasse 
     <value>Argument "{0}": Konvertierung von "{1}" in "{2}" nicht möglich.</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>Die Spezifikationen für benannte Argumente müssen nach Angabe aller festen Argumente angezeigt werden.</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>Die Einschränkungen für den "{0}"-Typparameter der "{1}"-Methode müssen mit den Einschränkungen für den "{2}"-Typparameter der "{3}"-Schnittstellenmethode übereinstimmen. Verwenden Sie stattdessen eine explizite Schnittstellenimplementierung.</value>
@@ -5060,6 +5090,9 @@ Wenn solch eine Klasse als Basisklasse verwendet wird und die ableitende Klasse 
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>Ausdruckskörperindexer</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>"{0}": Keine Ableitung vom dynamischen Typ möglich.</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.es.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.es.resx
@@ -380,6 +380,9 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>Solo los miembros conformes a CLS pueden ser abstractos</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>El ensamblado y el módulo '{0}' no pueden tener como destino procesadores distintos.</value>
   </data>
@@ -468,7 +471,7 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
     <value>'{0}' no implementa el patrón '{1}'. '{2}' es ambiguo con '{3}'.</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>Opción "{0}" no válida para /langversion; debe ser ISO-1, ISO-2, Default, Latest o una versión válida en el intervalo entre 1 y 7.1.</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>Un nombre calificado con el alias no es una expresión.</value>
@@ -713,6 +716,9 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>La constante de punto flotante está fuera del intervalo del tipo '{0}'</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>No se puede emitir información de depuración para un texto de origen sin descodificar.</value>
   </data>
@@ -733,6 +739,9 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>Se esperaba una etiqueta final para el elemento '{0}'.</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>Los argumentos de tipo no están permitidos en el nombre del operador.</value>
@@ -872,11 +881,14 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>El tipo "{0}" del ensamblado "{1}" no se puede usar en los distintos límites de ensamblado porque tiene un argumento de tipo genérico que es un tipo de interoperabilidad incrustado.</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>El operador as se debe usar con un tipo de referencia o un tipo que acepte valores NULL ('{0}' es un tipo de valor que no acepta valores NULL)</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>El método abstracto '{0}' no se puede marcar como virtual</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>'{0}': las clases estáticas no pueden contener operadores definidos por el usuario</value>
@@ -1028,6 +1040,9 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>La expresión de filtro es una constante, puede quitar el filtro</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>La característica "{0}" no está disponible en C# 7.1. Use la versión de lenguaje {1} u otra superior.</value>
   </data>
@@ -1109,6 +1124,9 @@ Considere la posibilidad de suprimir la advertencia solo si tiene la seguridad d
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>El miembro '{0}' no oculta un miembro accesible. La palabra clave new no es necesaria.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>Un número que se aprobó en la directiva de preprocesador de advertencia #pragma no es un número de advertencia válido. Verifique que ese número representa una advertencia y no un error.</value>
   </data>
@@ -1126,6 +1144,9 @@ Considere la posibilidad de suprimir la advertencia solo si tiene la seguridad d
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>#r solo se puede usar en scripts</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>Ya hay un árbol de sintaxis</value>
@@ -1322,6 +1343,9 @@ Considere la posibilidad de suprimir la advertencia solo si tiene la seguridad d
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>Opción de alias de referencia no válida: '{0}=', falta el nombre de archivo</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>Los miembros del campo de solo lectura '{0}' no se pueden devolver por referencia.</value>
   </data>
@@ -1347,7 +1371,7 @@ Considere la posibilidad de suprimir la advertencia solo si tiene la seguridad d
     <value>Un evento de Windows Runtime no se puede pasar como parámetro out o ref.</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>La instancia de tipo '{0}' no se puede usar dentro de una función anónima, una expresión de consulta, un bloque iterador ni un método asincrónico</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>'{0}' no implementa el miembro de interfaz '{1}'. '{2}' no puede implementar '{1}' porque no tiene el tipo de valor devuelto coincidente de '{3}'.</value>
@@ -1828,7 +1852,7 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
     <value>El operando de un operador de incremento o decremento debe ser una variable, una propiedad o un indizador</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>El modificador /embed se admite únicamente cuando se emite un archivo PDB portátil (/debug:portable o /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>'{0}' no puede ser externo y abstracto a la vez</value>
@@ -3111,8 +3135,8 @@ Si se utiliza una clase de este tipo como clase base y si la clase derivada defi
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>Ambigüedad entre '{0}' y '{1}'</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>Solo los métodos, las clases, las estructuras o las interfaces pueden ser parciales</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>Error de sintaxis de línea de comandos: falta el GUID para la opción '{1}'</value>
@@ -3191,143 +3215,146 @@ Si se utiliza una clase de este tipo como clase base y si la clase derivada defi
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Opciones del compilador de Visual C#
+                              Visual C# Compiler Options
 
-                        - ARCHIVOS DE SALIDA -
- /out:&lt;archivo&gt;                   Especificar el nombre del archivo de salida (predeterminado: nombre base del archivo
-                               con clase principal o primer archivo)
- /target:exe                   Compilar un archivo ejecutable de consola (predeterminado) (forma
-                               corta: /t:exe)
- /target:winexe                Compilar un archivo ejecutable de Windows (forma corta:
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               Compilar una biblioteca (forma corta: /t:library)
- /target:module                Compilar un módulo que se puede agregar a otro
-                               ensamblado (forma corta: /t:module)
- /target:appcontainerexe       Compilar un archivo ejecutable Appcontainer (forma corta:
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              Compilar un archivo intermedio de Windows Runtime
-                               que WinMDExp consume (forma corta: /t:winmdobj)
- /doc:&lt;archivo&gt;                   Archivo de documentación XML para generar
- /refout:&lt;archivo&gt;                Salida del ensamblado de referencia para generar
- /platform:&lt;cadena&gt;            Limitar en qué plataformas se puede ejecutar este código: x86,
-                               Itanium, x64, arm, anycpu32bitpreferred o
-                               anycpu. El valor predeterminado es anycpu.
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        - ARCHIVOS DE ENTRADA -
- /recurse:&lt;carácter comodín&gt;           Incluir todos los archivos en el directorio y los
-                               subdirectorios actuales según las especificaciones del
-                               carácter comodín
- /reference:&lt;alias&gt;=&lt;archivo&gt;     Metadatos de referencia del archivo de ensamblado
-                               especificado mediante el alias dado (forma corta: /r)
- /reference:&lt;lista de archivos&gt;        Metadatos de referencia de los archivos de ensamblado
-                               especificados (forma corta: /r)
- /addmodule:&lt;lista de archivos &gt;        Vincular los módulos especificados en este ensamblado
- /link:&lt;lista de archivos &gt;             Insertar metadatos de los archivos de ensamblado de
-                               interoperabilidad especificados (forma corta: /l)
- /analyzer:&lt;lista de archivos &gt;         Ejecutar los analizadores de este ensamblado
-                               (forma corta: /a)
- /additionalfile:&lt;lista de archivos &gt;   Archivos adicionales que no afectan directamente a la
-                               generación de código, pero que pueden usar los analizadores para producir
-                               errores o advertencias.
- /embed                        Insertar todos los archivos de origen en el PDB.
- /embed:&lt;lista de archivos &gt;            Insertar archivos específicos en el PDB
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        - RECURSOS -
- /win32res:&lt;archivo&gt;              Especificar un archivo de recursos Win32 (.res)
- /win32icon:&lt;archivo&gt;             Usar este icono para la salida
- /win32manifest:&lt;archivo&gt;         Especificar un archivo de manifiesto Win32 (.xml)
- /nowin32manifest              No incluir el manifiesto Win32 predeterminado
- /resource:&lt;info recurso&gt;           Insertar el recurso especificado (forma corta: /res)
- /linkresource:&lt;info recurso&gt;       Vincular el recurso especificado a este ensamblado
-                               (forma corta: /linkres), donde el formato de la información del recurso
-                               es &lt;archivo&gt;[,&lt;nombre de cadena&gt;[,public|private]]
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        - GENERACIÓN DE CÓDIGO -
- /debug[+|-]                   Emitir información de depuración
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               Especificar tipo de depuración (“full” es el valor predeterminado,
-                               “portable” es un formato multiplataforma,
-                               “embedded” es un formato multiplataforma insertado en
-                               el archivo.dll o .exe de destino)
- /optimize[+|-]                Permitir optimizaciones (forma corta: /o)
- /deterministic                Producir un ensamblado determinista
-                               (que incluya el GUID y la marca de tiempo de la versión del módulo)
- /refonly                      Producir un ensamblado de referencia en lugar de la salida principal
- /instrument:TestCoverage      Producir un ensamblado instrumentado para recopilar
-                               información de cobertura
- /sourcelink:&lt;archivo&gt;            Información del vínculo de origen para insertar en el PDB.
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        - ERRORES Y ADVERTENCIAS -
- /warnaserror[+|-]             Notificar todas las advertencias como errores
- /warnaserror[+|-]:&lt;lista de advertencias &gt; Notificar advertencias específicas como errores
- /warn:&lt;n&gt;                     Establecer nivel de advertencia (0-4) (forma corta: /w)
- /nowarn:&lt;lista de advertencias &gt;           Deshabilitar mensajes de advertencia específicos
- /ruleset:&lt;archivo&gt;               Especificar un archivo de conjunto de reglas que deshabilite
-                               diagnósticos específicos.
- /errorlog:&lt;archivo&gt;              Especificar un archivo para registrar todos los diagnósticos del compilador y el
-                               analizador.
- /reportanalyzer               Notificar información adicional del analizador, como el
-                               tiempo de ejecución.
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        - LENGUAJE -
- /checked[+|-]                 Generar comprobaciones de desbordamiento
- /unsafe[+|-]                  Permitir código “no seguro”
- /define:&lt;lista de símbolos &gt;         Definir símbolos de compilación condicional (forma
-                               corta: /d)
- /langversion:&lt;cadena&gt;         Especificar modo de versión del lenguaje: ISO-1, ISO-2, 3,
-                               4, 5, 6, 7, 7.1, predeterminado o más reciente
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        - SEGURIDAD -
- /delaysign[+|-]               Retrasar firma del ensamblado usando solo la parte pública
-                               de la clave de nombre seguro
- /publicsign[+|-]              Publicar firma del ensamblado usando solo la parte pública
-                               de la clave de nombre seguro
- /keyfile:&lt;archivo&gt;               Especificar un archivo de clave de nombre seguro
- /keycontainer:&lt;cadena&gt;        Especificar un contenedor de claves de nombres seguros
- /highentropyva[+|-]           Habilitar ASLR de alta entropía
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        - VARIOS -
- @&lt;archivo&gt;                       Leer archivo de respuesta para ver más opciones
- /help                         Mostrar este mensaje de uso (forma corta: /?)
- /nologo                       Suprimir mensaje de copyright del compilador
- /noconfig                     No incluir automáticamente el archivo CSC.RSP
- /parallel[+|-]                Compilación simultánea.
- /version                      Mostrar el número de versión del compilador y salir.
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
 
-                        - AVANZADO -
- /baseaddress:&lt;dirección&gt;        Dirección base de la biblioteca que se compilará
- /checksumalgorithm:&lt;algoritmo&gt;      Especificar el algoritmo para calcular la suma de comprobación
-                               del archivo de origen almacenado en PDB. Los valores admitidos son:
-                               SHA1 (predeterminado) o SHA256.
- /codepage:&lt;n&gt;                 Especificar la página de código que se usará al abrir los archivos de
-                               origen
- /utf8output                   Mensajes de compilador de salida en codificación UTF-8
- /main:&lt;tipo&gt;                  Especificar el tipo que contiene el punto de entrada
-                               (ignorar todos los demás puntos de entrada posibles) (forma
-                               corta: /m)
- /fullpaths                    El compilador genera rutas de acceso completas
- /filealign:&lt;n&gt;                Especificar la alineación usada para las secciones del
-                               archivo de salida
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
  /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                               Especificar una asignación para los nombres de rutas de acceso de origen
-                               emitidos por el compilador.
- /pdb:&lt;archivo&gt;                   Especificar nombre de archivo de información de depuración (valor predeterminado:
-                               nombre de archivo de salida con la extensión .pdb)
- /errorendlocation             Línea y columna de salida de la ubicación final de
-                               cada error
- /preferreduilang              Especificar el nombre del lenguaje de salida preferido.
- /nostdlib[+|-]                No hacer referencia a la biblioteca estándar (mscorlib.dll)
- /subsystemversion:&lt;cadena&gt;    Especificar versión del subsistema de este ensamblado
- /lib:&lt;lista de archivos&gt;              Especificar directorios adicionales en los que buscar
-                               referencias
- /errorreport:&lt;cadena&gt;         Especificar cómo tratar los errores internos del compilador:
-                               avisar, enviar, poner en cola o ninguno. El valor predeterminado es
-                               poner en cola.
- /appconfig:&lt;archivo&gt;             Especificar un archivo de configuración de aplicación
-                               que contenga opciones de enlace de ensamblado
- /moduleassemblyname:&lt;cadena&gt;  Nombre del ensamblado del que este módulo
-                               formará parte
- /modulename:&lt;cadena&gt;          Especificar el nombre del módulo de origen
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
+                               queue.
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3637,7 +3664,7 @@ Si se utiliza una clase de este tipo como clase base y si la clase derivada defi
     <value>CallerMemberNameAttribute no se puede aplicar porque no hay conversiones estándar del tipo '{0}' al tipo '{1}'</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>No se puede devolver por referencia un miembro del parámetro '{0}' porque no es un parámetro de tipo ref o out.</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(Ubicación del símbolo relacionado con el error anterior)</value>
@@ -3682,7 +3709,7 @@ Si se utiliza una clase de este tipo como clase base y si la clase derivada defi
     <value>No se pude devolver por referencia un parámetro '{0}' porque no es de tipo ref o out.</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>Los elementos definidos en un espacio de nombres no se pueden declarar explícitamente como private, protected o protected internal</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>La opción /moduleassemblyname únicamente se puede especificar cuando cree un tipo de destino de 'module'</value>
@@ -3851,6 +3878,9 @@ Si se utiliza una clase de este tipo como clase base y si la clase derivada defi
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>'{0}' define el operador == o el operador != pero no invalida Object.GetHashCode()</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>Uno de los parámetros de un operador binario debe ser el tipo contenedor</value>
@@ -4315,7 +4345,7 @@ Si se utiliza una clase de este tipo como clase base y si la clase derivada defi
     <value>El parámetro de tipo '{1}' tiene la restricción 'struct'; por tanto, '{1}' no se puede usar como restricción para '{0}'</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>El tipo predefinido '{0}' no está definido ni importado</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>El argumento de tipo no puede ser NULL</value>
@@ -4480,7 +4510,7 @@ Si se utiliza una clase de este tipo como clase base y si la clase derivada defi
     <value>Argumento {0}: no se puede convertir de '{1}' a '{2}'</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>Las especificaciones de argumento con nombre deben aparecer después de haber especificado todos los argumentos fijos</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>Las restricciones para el parámetro de tipo '{0} del método '{1} deben coincidir con las restricciones del parámetro de tipo '{2} del método de interfaz '{3}. Si lo prefiere, puede usar una implementación de interfaz explícita.</value>
@@ -5060,6 +5090,9 @@ Si se utiliza una clase de este tipo como clase base y si la clase derivada defi
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>indexador con forma de expresión</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>'{0}': no se puede derivar del tipo dinámico</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.fr.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.fr.resx
@@ -380,6 +380,9 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>Seuls les membres conformes CLS peuvent être abstraits</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>L'assembly et le module '{0}' ne peuvent pas cibler des processeurs différents.</value>
   </data>
@@ -468,7 +471,7 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
     <value>'{0}' n'implémente pas le modèle '{1}'. '{2}' est ambigu avec '{3}'.</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>Option non valide '{0}' pour /langversion. Valeur attendue : ISO-1, ISO-2, Default, Latest ou un numéro de version valide compris entre 1 et 7.1.</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>Un nom qualifié d'alias n'est pas une expression.</value>
@@ -713,6 +716,9 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>La constante à virgule flottante sort de la plage du type '{0}'</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>Impossible d'émettre des informations de débogage pour un texte source sans encodage.</value>
   </data>
@@ -733,6 +739,9 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>Une balise de fin était attendue pour l'élément '{0}'.</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>Les arguments de type ne sont pas autorisés dans l'opérateur nameof.</value>
@@ -872,11 +881,14 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>Impossible d'utiliser le type '{0}' de l'assembly '{1}' au-delà des limites de l'assembly, car il a un argument de type générique qui est un type interop incorporé.</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>L'opérateur as doit être utilisé avec un type référence ou un type Nullable ('{0}' est un type valeur qui n'autorise pas les valeurs null)</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>La méthode abstraite '{0}' ne peut pas être marquée comme virtual</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>'{0}' : les classes static ne peuvent pas contenir d'opérateurs définis par l'utilisateur</value>
@@ -1028,6 +1040,9 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>L'expression de filtre est une constante ; supprimez le filtre</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>La fonctionnalité '{0}' n'est pas disponible dans C# 7.1. Utilisez la version de langage {1} ou une version ultérieure.</value>
   </data>
@@ -1109,6 +1124,9 @@ Supprimez l'avertissement seulement si vous êtes sûr de ne pas vouloir attendr
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>Le membre '{0}' ne masque pas de membre accessible. Le mot clé new n'est pas nécessaire.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>Un numéro transmis à la directive de préprocesseur d'avertissement #pragma n'est pas correct. Veuillez vérifier que ce numéro représente un avertissement et non une erreur.</value>
   </data>
@@ -1126,6 +1144,9 @@ Supprimez l'avertissement seulement si vous êtes sûr de ne pas vouloir attendr
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>#r n'est autorisé que dans les scripts</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>Arborescence de syntaxe déjà présente</value>
@@ -1322,6 +1343,9 @@ Supprimez l'avertissement seulement si vous êtes sûr de ne pas vouloir attendr
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>Option d'alias de référence non valide : '{0}=' -- nom de fichier manquant</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>Impossible de retourner les membres du champ readonly '{0}' par référence</value>
   </data>
@@ -1347,7 +1371,7 @@ Supprimez l'avertissement seulement si vous êtes sûr de ne pas vouloir attendr
     <value>Un événement Windows Runtime ne peut pas être passé comme paramètre out ou ref.</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>Impossible d'utiliser une instance de type '{0}' dans une fonction anonyme , une expression de requête, un bloc itérateur ou une méthode async</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>'{0}' n'implémente pas le membre d'interface '{1}'. '{2}' ne peut pas implémenter '{1}', car il ne possède pas le type de retour correspondant '{3}'.</value>
@@ -1828,7 +1852,7 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
     <value>L'opérande d'un opérateur d'incrémentation ou de décrémentation doit être une variable, une propriété ou un indexeur</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Le commutateur /embed est uniquement pris en charge durant l'émission d'un fichier PDB portable (/debug:portable ou /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>'{0}' ne peut pas être à la fois extern et abstract</value>
@@ -3111,8 +3135,8 @@ Si une telle classe est utilisée en tant que classe de base et si la classe dé
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>Ambiguïté entre '{0}' et '{1}'</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>Seules les méthodes, classes, structs ou interfaces peuvent être partielles</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>Erreur de syntaxe de ligne de commande : Guid manquant pour l'option '{1}'</value>
@@ -3191,143 +3215,146 @@ Si une telle classe est utilisée en tant que classe de base et si la classe dé
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Options du compilateur Visual C#
+                              Visual C# Compiler Options
 
-                        - FICHIERS DE SORTIE -
- /out:&lt;fichier&gt;                Spécifier un nom de fichier de sortie (par défaut : nom de base du
-                               fichier avec classe principale ou premier fichier)
- /target:exe                   Générer un fichier exécutable console (par défaut) (forme
-                               abrégée : /t:exe)
- /target:winexe                Générer un fichier exécutable Windows (forme abrégée :
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               Générer une bibliothèque (forme abrégée : /t:library)
- /target:module                Générer un module qui peut être ajouté à un autre
-                               assembly (forme abrégée : /t:module)
- /target:appcontainerexe       Générer un exécutable Appcontainer (forme abrégée :
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              Générer un fichier intermédiaire Windows Runtime
-                               consommé par WinMDExp (forme abrégée : /t:winmdobj)
- /doc:&lt;fichier&gt;                Fichier de documentation XML à générer
- /refout:&lt;fichier&gt;             Référencer la sortie d'assembly à générer
- /platform:&lt;chaîne&gt;            Limiter les plateformes sur lesquelles ce code peut s'exécuter : x86,
-                               Itanium, x64, arm, anycpu32bitpreferred ou
-                               anycpu. La valeur par défaut est anycpu.
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        - FICHIERS D'ENTRÉE -
- /recurse:&lt;générique&gt;          Inclure tous les fichiers dans le répertoire et
-                               les sous-répertoires actifs en fonction des
-                               spécifications de caractères génériques
- /reference:&lt;alias&gt;=&lt;fichier&gt;  Référencer les métadonnées à partir du
-                               fichier d'assembly spécifié via l'alias indiqué (forme abrégée : /r)
- /reference:&lt;liste_fichiers&gt;   Référencer les métadonnées à partir
-                               des fichiers d'assembly spécifiés (forme abrégée : /r)
- /addmodule:&lt;liste_fichiers&gt;   Lier les modules spécifiés dans cet assembly
- /link:&lt;liste_fichiers&gt;        Incorporer les métadonnées à partir des
-                               fichiers d'assembly d'interopérabilité spécifiés (forme abrégée : /l)
- /analyzer:&lt;liste_fichiers&gt;    Exécuter les analyseurs à partir de cet assembly
-                               (Forme abrégée : /a)
- /additionalfile:&lt;liste_fich.&gt; Fichiers supplémentaires qui n'affectent pas directement
-                               la génération de code mais qui peuvent être utilisés par les analyseurs pour produire
-                               des erreurs ou des avertissements.
- /embed                        Incorporer tous les fichiers sources dans le fichier PDB.
- /embed:&lt;liste_fichiers&gt;       Incorporer des fichiers spécifiques dans le fichier PDB
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        - RESSOURCES -
- /win32res:&lt;fichier&gt;           Spécifier un fichier de ressources Win32 (.res)
- /win32icon:&lt;fichier&gt;          Utiliser cette icône pour la sortie
- /win32manifest:&lt;fichier&gt;      Spécifier un fichier manifeste (.xml) Win32
- /nowin32manifest              Ne pas inclure le manifeste Win32 par défaut
- /resource:&lt;resinfo&gt;           Incorporer la ressource spécifiée (forme abrégée : /res)
- /linkresource:&lt;resinfo&gt;       Lier la ressource spécifiée à cet assembly
-                               (forme abrégée : /linkres), où le format resinfo
-                               est &lt;fichier&gt;[,&lt;nom_chaîne&gt;[,public|private]]
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        - GÉNÉRATION DE CODE -
- /debug[+|-]                   Émettre des informations de débogage
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               Spécifier le type de débogage ('full' est la valeur par défaut,
-                               'portable' est un format multiplateforme,
-                               'embedded' est un format multiplateforme incorporé dans
-                               le fichier .dll ou .exe cible)
- /optimize[+|-]                Activer les optimisations (forme abrégée : /o)
- /deterministic                Produire un assembly déterministe
-                               (en incluant le GUID et l'horodateur de la version du module)
- /refonly                      Produire un assembly de référence à la place de la sortie principale
- /instrument:TestCoverage      Produire un assembly instrumenté pour collecter
-                               les informations de couverture
- /sourcelink:&lt;fichier&gt;         Informations du lien source à incorporer dans le fichier PDB.
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        - ERREURS ET AVERTISSEMENTS -
- /warnaserror[+|-]             Signaler tous les avertissements comme des erreurs
- /warnaserror[+|-]:&lt;avertiss.&gt; Signaler des avertissements spécifiques comme des erreurs
- /warn:&lt;n&gt;                     Définir le niveau d'avertissement (0-4) (forme abrégée : /w)
- /nowarn:&lt;liste avertiss.&gt;     Désactiver des messages d'avertissement spécifiques
- /ruleset:&lt;fichier&gt;            Spécifier un fichier ruleset qui désactive des
-                               diagnostics spécifiques.
- /errorlog:&lt;fichier&gt;           Spécifier un fichier pour journaliser tous les diagnostics du compilateur
-                               et de l'analyseur.
- /reportanalyzer               Indiquer des informations supplémentaires sur l'analyseur, comme
-                               la durée d'exécution.
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        - LANGAGE -
- /checked[+|-]                 Générer des contrôles de dépassement de capacité
- /unsafe[+|-]                  Autoriser du code 'unsafe'
- /define:&lt;liste_symboles&gt;      Définir les symboles de compilation conditionnelle (forme
-                               abrégée : /d)
- /langversion:&lt;chaîne&gt;         Spécifier le mode de version de langage : ISO-1, ISO-2, 3,
-                               4, 5, 6, 7, 7.1, Default ou Latest
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        - SÉCURITÉ -
- /delaysign[+|-]               Différer la signature de l'assembly en utilisant uniquement
-                               la partie publique de la clé de nom fort
- /publicsign[+|-]              Signer publiquement l'assembly en utilisant uniquement
-                               la partie publique de la clé de nom fort
- /keyfile:&lt;fichier&gt;            Spécifier un fichier de clé de nom fort
- /keycontainer:&lt;chaîne&gt;        Spécifier un conteneur de clé de nom fort
- /highentropyva[+|-]           Activer la randomisation du format d'espace d'adresse d'entropie élevée
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        - DIVERS -
- @&lt;fichier&gt;                    Lire le fichier réponse pour plus d'options
- /help                         Afficher ce message d'utilisation (forme abrégée : /?)
- /nologo                       Supprimer le message de copyright du compilateur
- /noconfig                     Ne pas inclure automatiquement un fichier CSC.RSP
- /parallel[+|-]                Build simultanée.
- /version                      Afficher le numéro de version du compilateur et quitter le processus.
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
 
-                        - AVANCÉ -
- /baseaddress:&lt;adresse&gt;        Adresse de base de la bibliothèque à générer
- /checksumalgorithm:&lt;alg&gt;      Spécifier l'algorithme de calcul de la somme de contrôle
-                               de fichier source stockée dans le fichier PDB. Valeurs prises en charge :
-                               SHA1 (par défaut) ou SHA256.
- /codepage:&lt;n&gt;                 Spécifier la page de codes à utiliser à l'ouverture
-                               des fichiers sources
- /utf8output                   Messages du compilateur de sortie encodés en UTF-8
- /main:&lt;type&gt;                  Spécifier le type qui contient le point d'entrée
-                               (ignorer tous les autres points d'entrée possibles) (forme
-                               abrégée : /m)
- /fullpaths                    Le compilateur génère des chemins qualifiés complets
- /filealign:&lt;n&gt;                Spécifier l'alignement utilisé pour les
-                               sections du fichier de sortie
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
  /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                               Spécifier un mappage pour les noms de chemins sources sortis par
-                               le compilateur.
- /pdb:&lt;fichier&gt;                Spécifier le nom du fichier des informations de débogage (par défaut :
-                               nom du fichier de sortie avec l'extension .pdb)
- /errorendlocation             Ligne et colonne de sortie de l'emplacement final de
-                               chaque erreur
- /preferreduilang              Spécifier le nom du langage de sortie préféré.
- /nostdlib[+|-]                Ne pas référencer la bibliothèque standard (mscorlib.dll)
- /subsystemversion:&lt;chaîne&gt;    Spécifier la version du sous-système de cet assembly
- /lib:&lt;liste fichiers&gt;         Spécifier des répertoires supplémentaires dans lesquels rechercher les
-                               références
- /errorreport:&lt;chaîne&gt;         Spécifier comment gérer les erreurs internes du compilateur :
-                               prompt, send, queue ou none. La valeur par défaut est
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
                                queue.
- /appconfig:&lt;fichier&gt;          Spécifier un fichier de configuration de l'application
-                               contenant des paramètres de liaison d'assembly
- /moduleassemblyname:&lt;chaîne&gt;  Nom de l'assembly dont ce module
-                               doit faire partie
- /modulename:&lt;chaîne&gt;          Spécifier le nom du module source
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3637,7 +3664,7 @@ Si une telle classe est utilisée en tant que classe de base et si la classe dé
     <value>Impossible d'appliquer CallerMemberNameAttribute, car il n'existe pas de conversion standard du type '{0}' en type '{1}'</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>Impossible de retourner un membre du paramètre '{0}' par référence, car il ne s'agit pas d'un paramètre ref ou out</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(Emplacement du symbole par rapport à l'erreur précédente)</value>
@@ -3682,7 +3709,7 @@ Si une telle classe est utilisée en tant que classe de base et si la classe dé
     <value>Impossible de retourner un paramètre '{0}' par référence, car il ne s'agit pas d'un paramètre ref ou out</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>Les éléments définis dans un espace de noms ne peuvent pas être explicitement déclarés comme private, protected ou protected internal</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>L'option /moduleassemblyname ne peut être spécifiée que lors de la génération d'un type cible de 'module'</value>
@@ -3851,6 +3878,9 @@ Si une telle classe est utilisée en tant que classe de base et si la classe dé
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>'{0}' définit l'opérateur == ou l'opérateur != mais ne se substitue pas à Object.GetHashCode()</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>Un des paramètres d'un opérateur binaire doit être le type conteneur</value>
@@ -4315,7 +4345,7 @@ Si une telle classe est utilisée en tant que classe de base et si la classe dé
     <value>Le paramètre de type '{1}' a la contrainte 'struct', donc '{1}' ne peut pas être utilisé comme contrainte pour '{0}'</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>Le type prédéfini '{0}' n'est pas défini ou importé</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>L'argument de type ne peut pas avoir la valeur null</value>
@@ -4480,7 +4510,7 @@ Si une telle classe est utilisée en tant que classe de base et si la classe dé
     <value>Argument {0} : conversion impossible de '{1}' en '{2}'</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>Les spécifications d'argument nommé doivent s'afficher après la spécification de tous les arguments fixes</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>Les contraintes pour le paramètre de type '{0}' de la méthode '{1}' doivent correspondre aux contraintes pour le paramètre de type '{2}' de la méthode d'interface '{3}'. Utilisez plutôt une implémentation d'interface explicite.</value>
@@ -5060,6 +5090,9 @@ Si une telle classe est utilisée en tant que classe de base et si la classe dé
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>indexeur expression-bodied</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>'{0}' : dérivation impossible du type dynamic</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.it.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.it.resx
@@ -380,6 +380,9 @@ Un blocco catch() dopo un blocco catch (System.Exception e) è in grado di rilev
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>Solo i membri conformi a CLS possono essere di tipo abstract</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>L'assembly e il modulo '{0}' non possono essere destinati a processori diversi.</value>
   </data>
@@ -468,7 +471,7 @@ Un blocco catch() dopo un blocco catch (System.Exception e) è in grado di rilev
     <value>'{0}' non implementa il modello '{1}'. '{2}' è ambiguo con '{3}'.</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>L'opzione '{0}' non è valida per /langversion. Deve essere ISO-1, ISO-2, Default, Latest o un numero di versione valido compreso tra 1 e 7.1.</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>Un nome qualificato da alias non è un'espressione.</value>
@@ -713,6 +716,9 @@ Un blocco catch() dopo un blocco catch (System.Exception e) è in grado di rilev
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>La costante a virgola mobile non è inclusa nell'intervallo di tipo '{0}'</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>Non è possibile creare le informazioni di debug per un testo di origine senza codifica.</value>
   </data>
@@ -733,6 +739,9 @@ Un blocco catch() dopo un blocco catch (System.Exception e) è in grado di rilev
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>È previsto un tag finale per l'elemento '{0}'.</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>Gli argomenti di tipo non sono consentiti nell'operatore nameof.</value>
@@ -872,11 +881,14 @@ Un blocco catch() dopo un blocco catch (System.Exception e) è in grado di rilev
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>Non è possibile usare il tipo '{0}' dell'assembly '{1}' tra limiti di assembly perché contiene un argomento tipo generico che corrisponde a un tipo di interoperabilità incorporato.</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>L'operatore as deve essere usato con un tipo riferimento o con un tipo nullable ('{0}' è un tipo di valore non nullable)</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>Il metodo astratto '{0}' non può essere contrassegnato come virtual</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>'{0}': le classi statiche non possono contenere operatori definiti dall'utente</value>
@@ -1028,6 +1040,9 @@ Un blocco catch() dopo un blocco catch (System.Exception e) è in grado di rilev
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>L'espressione di filtro non è costante. Provare a rimuovere il filtro</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>La funzionalità '{0}' non è disponibile C# 7.1. Usare la versione {1} o versioni successive del linguaggio.</value>
   </data>
@@ -1109,6 +1124,9 @@ Come procedura consigliata, è consigliabile attendere sempre la chiamata.
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>Il membro '{0}' non nasconde un membro accessibile. La parola chiave new non è obbligatoria.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>Un numero che è stato passato alla direttiva per il preprocessore di avvisi #pragma non corrisponde a un numero di avviso valido. Verificare che il numero rappresenti un avviso e non un errore.</value>
   </data>
@@ -1126,6 +1144,9 @@ Come procedura consigliata, è consigliabile attendere sempre la chiamata.
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>#r è consentito solo negli script</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>L'albero della sintassi è già presente</value>
@@ -1322,6 +1343,9 @@ Come procedura consigliata, è consigliabile attendere sempre la chiamata.
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>L'opzione dell'alias di riferimento non è valida: '{0}='. Manca il nome file</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>I membri del campo di sola lettura '{0}' non possono essere restituiti per riferimento</value>
   </data>
@@ -1347,7 +1371,7 @@ Come procedura consigliata, è consigliabile attendere sempre la chiamata.
     <value>Un evento Windows Runtime non può essere passato come parametro out o ref.</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>L'istanza di tipo '{0}' non può essere usata all'interno di una funzione anonima, un'espressione di query, un blocco iteratore o un metodo asincrono</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>'{0}' non implementa il membro di interfaccia '{1}'. '{2}' non può implementare '{1}' perché non ha il tipo restituito corrispondente di '{3}'.</value>
@@ -1828,7 +1852,7 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
     <value>L'operando di un operatore di incremento o decremento deve essere una variabile, una proprietà o un indicizzatore</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>L'opzione /embed è supportata solo quando si crea il file PDB portatile (/debug:portable o /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>'{0}' non può essere contemporaneamente di tipo extern e abstract</value>
@@ -3111,8 +3135,8 @@ Se si usa tale classe come classe base e se la classe di derivazione definisce u
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>Ambiguità tra '{0}' e '{1}'</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>Solo metodi, classi, strutture o interfacce possono essere parziali</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>Errore nella sintassi della riga di comando: manca il GUID per l'opzione '{1}'</value>
@@ -3191,141 +3215,146 @@ Se si usa tale classe come classe base e se la classe di derivazione definisce u
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Opzioni del compilatore Visual C#
+                              Visual C# Compiler Options
 
-                        - FILE DI OUTPUT -
- /out:&lt;file&gt;                   Specifica il nome del file di output (impostazione predefinita: 
-nome di base del file con la classe principale o primo file)
- /target:exe                   Compila un file eseguibile da console (impostazione predefinita). 
-                               Forma breve: /t:exe
- /target:winexe                Compila un file eseguibile Windows. Forma breve: 
-                               /t:winexe
- /target:library               Compila una libreria. Forma breve: /t:library
- /target:module                Compila un modulo che può essere aggiunto a un altro assembly. 
-                               Forma breve: /t:module
- /target:appcontainerexe       Compila un file eseguibile Appcontainer. Forma breve: 
-                               /t:appcontainerexe
- /target:winmdobj              Compila un file Windows Runtime intermedio 
-                               usato da WinMDExp. Forma breve: /t:winmdobj
- /doc:&lt;file&gt;                   File di documentazione XML da generare
- platform:&lt;stringa&gt;            Limita le piattaforme in cui è possibile eseguire il codice: x86,
-                               Itanium, x64, arm, anycpu32bitpreferred o 
-                               anycpu. Il valore predefinito è anycpu.
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
+                               /t:winexe)
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
+                               /t:appcontainerexe)
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        - FILE DI INPUT -
- /recurse:&lt;caratterijolly&gt;           Include tutti i file presenti nella directory corrente e
-                               nelle relative sottodirectory in base
-                               ai caratteri jolly specificati
- /reference:&lt;alias&gt;=&lt;file&gt;     Crea un riferimento ai metadati dal file di assembly specificato 
-                               usando l'alias indicato. Forma breve: /r
- /reference:&lt;elenco file&gt;        Crea un riferimento ai metadati dai file di assembly 
-                               specificati. Forma breve: /r
- /addmodule:&lt;elenco file&gt;        Collega i moduli specificati nell'assembly
- /link:&lt;elenco file&gt;             Incorpora metadati dai file di assembly di 
-                               interoperabilità specificati. Forma breve: /l
- /analyzer:&lt;elenco file&gt;             Esegue gli analizzatori dall'assembly.
-                               Forma breve: /a
- /additionalfile:&lt;elenco file&gt;       File aggiuntivi che non influiscono
-                                   direttamente sulla generazione del codice ma possono essere usati
-                                  dagli analizzatori per produrre errori o avvisi.
- /embed                        Incorpora tutti i file di origine nel PDB.
- /embed:&lt;elenco file&gt;            Incorpora file specifici nel PDB
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        - RISORSE -
- /win32res:&lt;file&gt;              Consente di specificare un file di risorse Win32 (.res)
- /win32icon:&lt;file&gt;             Usa questa icona per l'output
- /win32manifest:&lt;file&gt;         Consente di specificare un file manifesto Win32 (.xml)
- /nowin32manifest              Non include il manifesto Win32 predefinito
- /resource:&lt;inforisorsa&gt;           Incorpora la risorsa specificata. Forma breve: /res
- /linkresource:&lt;inforisorsa&gt;       Collega la risorsa specificata all'assembly.
-                               Forma breve: /linkres. Il formato di inforisorsa 
-                               è &lt;file&gt;[,&lt;nome stringa&gt;[,public|private]]
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        - GENERAZIONE DEL CODICE -
- /debug[+|-]                   Crea le informazioni di debug
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               Specifica il tipo di debug ('full' è l'impostazione predefinita, 
-                               'portable' è un formato multipiattaforma,
-                               'embedded' è un formato multipiattaforma incorporato nel 
-                               file DLL o EXE di destinazione)
- /optimize[+|-]                Abilita le ottimizzazioni. Forma breve: /o
- /deterministic                Produce un assembly deterministico
-                               (che include GUID e timestamp della versione del modulo)
- /instrument:TestCoverage      Produce un assembly instrumentato per raccogliere
-                               informazioni sul code coverage
- /sourcelink:&lt;file&gt;            Informazioni sul collegamento di origine da incorporare nel PDB portatile.
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        - ERRORI E AVVISI -
- /warnaserror[+|-]             Segnala tutti gli avvisi come errori
- /warnaserror[+|-]:&lt;elenco avvisi&gt; Segnala determinati avvisi come errori
- /warn:&lt;n&gt;                     Imposta il livello di avviso (0-4). Forma breve: /w
- /nowarn:&lt;elenco avvisi&gt;           Disabilita messaggi di avviso specifici
- /ruleset:&lt;file&gt;               Consente di specificare un file di set di regole che disabilita
-                               diagnostica specifica.
- /errorlog:&lt;file&gt;              Consente di specificare un file in cui registrare tutte le diagnostiche del 
-                               compilatore e dell'analizzatore.
- /reportanalyzer               Restituisce informazioni aggiuntive dell'analizzatore, ad
-                               esempio il tempo di esecuzione.
- 
-                        - LINGUAGGIO -
- /checked[+|-]                 Genera controlli dell'overflow
- /unsafe[+|-]                  Consente codice 'unsafe'
- /define:&lt;elenco simboli&gt;         Consente di definire simboli di compilazione condizionale. Forma 
-                               breve: /d
- /langversion:&lt;stringa&gt;         Consente di specificare la modalità della versione del linguaggio: ISO-1, ISO-2, 3, 
-                               4, 5, 6, 7, 7.1, Default o Latest
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        - SICUREZZA -
- /delaysign[+|-]                   Ritarda la firma dell'assembly usando solo la parte pubblica della
-                                  chiave con nome sicuro
- /publicsign[+|-]              Firma pubblicamente l'assembly usando solo la parte pubblica
-                               della chiave con nome sicuro
- /keyfile:&lt;file&gt;               Consente di specificare un file di chiave con nome sicuro
- /keycontainer:&lt;stringa&gt;        Consente di specificare un contenitore di chiavi con nome sicuro
- /highentropyva[+|-]               Abilita ASLR a entropia elevata
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        - VARIE -
- @&lt;file&gt;                       Legge il file di risposta per altre opzioni
- /help                         Visualizza questo messaggio relativo alla sintassi. Forma breve: /?
- /nologo                       Non visualizza il messaggio di copyright del compilatore
- /noconfig                     Non include automaticamente il file CSC.RSP
- /parallel[+|-]                    Compilazione simultanea.
- /version                      Visualizza il numero di versione del compilatore ed esce.
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        - AVANZATE -
- /baseaddress:&lt;indirizzo&gt;        Indirizzo di base della libreria da compilare
- /checksumalgorithm:&lt;alg&gt;      Consente di specificare l'algoritmo per calcolare il checksum 
-                               del file di origine archiviato nel PDB. I valori supportati sono:
-                               SHA1 (predefinito) o SHA256.
- /codepage:&lt;n&gt;                 Consente di specificare la tabella codici da usare all'apertura dei file 
-                               di origine
- /utf8output                   Restituisce i messaggi del compilatore usando la codifica UTF-8
- /main:&lt;tipo&gt;                  Consente di specificare il tipo che contiene il punto di ingresso, 
-                               ignorando tutti gli altri punti di ingresso possibili. Forma 
-                               breve: /m
- /fullpaths                    Il compilatore genera percorsi completi
- /filealign:&lt;n&gt;                Consente di specificare l'allineamento usato per le sezioni del 
-                               file di output
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
+
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
  /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                               Consente di specificare un mapping per i nomi di percorso di origine
-                               visualizzati dal compilatore.
- /pdb:&lt;file&gt;                   Consente di specificare il nome del file di informazioni di debug (impostazione predefinita: 
-                               nome del file di output con estensione pdb)
- /errorendlocation             Riga e colonna di output della posizione finale di 
-                               ogni errore
- /preferreduilang              Consente di specificare il nome del linguaggio di output preferito.
- /nostdlib[+|-]                Omette i riferimenti alla libreria standard (mscorlib.dll)
- /subsystemversion:&lt;stringa&gt;    Consente di specificare la versione del sottosistema di questo assembly
- /lib:&lt;elenco file&gt;              Consente di specificare le directory aggiuntive in cui cercare i 
-                               riferimenti
- /errorreport:&lt;stringa&gt;         Consente di specificare come gestire gli errori interni del compilatore: 
-                               prompt, send, queue o none. L'impostazione predefinita è 
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
                                queue.
- /appconfig:&lt;file&gt;             Consente di specificare un file di configurazione dell'applicazione 
-                               contenente le impostazioni di binding dell'assembly
- /moduleassemblyname:&lt;stringa&gt;  Nome dell'assembly di cui farà parte 
-                               questo modulo
- /modulename:&lt;stringa&gt;          Consente di specificare il nome del modulo di origine
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3635,7 +3664,7 @@ nome di base del file con la classe principale o primo file)
     <value>Non è possibile applicare CallerMemberNameAttribute perché non sono disponibili conversioni standard dal tipo '{0}' al tipo '{1}'</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>Non è possibile restituire un membro del parametro '{0}' per riferimento perché non è un parametro out o ref</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(Posizione del simbolo relativo all'errore precedente)</value>
@@ -3680,7 +3709,7 @@ nome di base del file con la classe principale o primo file)
     <value>Non è possibile restituire un parametro '{0}' per riferimento perché non è un parametro out o ref</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>Gli elementi definiti in uno spazio dei nomi non possono essere dichiarati in modo esplicito come private, protected o protected internal</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>L'opzione /moduleassemblyname può essere specificata solo durante la compilazione del tipo di destinazione di 'module'</value>
@@ -3849,6 +3878,9 @@ nome di base del file con la classe principale o primo file)
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>'{0}' definisce l'operatore == o l'operatore != ma non esegue l'override di Object.GetHashCode()</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>Uno dei parametri di un operatore binario deve essere il tipo che lo contiene</value>
@@ -4313,7 +4345,7 @@ nome di base del file con la classe principale o primo file)
     <value>Il parametro di tipo '{1}' ha il vincolo 'struct'. Non è quindi possibile usare '{1}' come vincolo per '{0}'</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>Il tipo predefinito '{0}' non è definito né importato</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>L'argomento di tipo non può essere Null</value>
@@ -4478,7 +4510,7 @@ nome di base del file con la classe principale o primo file)
     <value>Argomento {0}: non è possibile convertire da '{1}' a '{2}'</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>Le specifiche di argomenti denominati devono trovarsi dopo tutti gli argomenti fissi specificati</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>I vincoli per il parametro di tipo '{0}' del metodo '{1}' devono corrispondere ai vincoli per il parametro di tipo '{2}' del metodo di interfaccia '{3}'. Provare a usare un'implementazione esplicita dell'interfaccia.</value>
@@ -5058,6 +5090,9 @@ nome di base del file con la classe principale o primo file)
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>indicizzatore con corpo di espressione</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>'{0}': non è possibile derivare dal tipo dinamico</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.ja.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.ja.resx
@@ -380,6 +380,9 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>抽象化できるのは CLS 準拠メンバーのみです</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>アセンブリとモジュール '{0}' で異なるプロセッサを対象にすることはできません。</value>
   </data>
@@ -468,7 +471,7 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
     <value>'{0}' は、パターン '{1}' を実装しません。'{2}' は、'{3}' で不適切です。</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>/langversion に対するオプション '{0}' は無効です。ISO-1、ISO-2、Default、Latest、1 から 7.1 までの範囲の有効なバージョンを指定する必要があります。</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>エイリアスで修飾された名前は式ではありません。</value>
@@ -713,6 +716,9 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>浮動小数点定数が型 '{0}' の範囲外です。</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>エンコーディングせずにソース テキストのデバッグ情報を作成することはできません。</value>
   </data>
@@ -733,6 +739,9 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>要素 '{0}' に終了タグが必要です。</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>nameof 演算子では型の引数を使用できません。</value>
@@ -872,11 +881,14 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>アセンブリ '{1}' の型 '{0}' には、埋め込み相互運用型のジェネリック型引数があるため、アセンブリ境界を越えて使用することはできません。</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>as 演算子は参照型または Null 許容型で使用してください ('{0}' は Null 非許容の値型です)</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>抽象メソッド '{0}' を virtual に指定することはできません。</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>'{0}': 静的クラスにユーザー定義の演算子を含めることはできません。</value>
@@ -1028,6 +1040,9 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>フィルター式は定数です。フィルターの削除を検討してください。</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>機能 '{0}' は C# 7.1 では使用できません。{1} 以上の言語バージョンをお使いください。</value>
   </data>
@@ -1109,6 +1124,9 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>メンバー '{0}' はアクセス可能なメンバーを非表示にしません。新しいキーワードは不要です。</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>#pragma 警告のプリプロセッサ ディレクティブに渡された番号は無効な警告番号です。番号がエラー番号ではなく警告番号を表していることを確認してください。</value>
   </data>
@@ -1126,6 +1144,9 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>#r はスクリプトでのみ許可されます。</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>構文ツリーが既に存在しています。</value>
@@ -1322,6 +1343,9 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>無効な参照エイリアス オプションです: '{0}=' -- ファイル名が指定されていません</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>読み取り専用フィールド '{0}' のメンバーを参照渡しで返すことはできません</value>
   </data>
@@ -1347,7 +1371,7 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
     <value>Windows ランタイム イベントを out または ref のパラメーターとして渡すことはできません。</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>型 '{0}' のインスタンスは、匿名関数、クエリ式、反復子ブロック、または非同期メソッドの中では使用できません。</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>'{0}' は、インターフェイス メンバー '{1}' を実装していません。'{2}' は一致する '{3}' の戻り値の型を持たないため、'{1}' を実装できません。</value>
@@ -1828,7 +1852,7 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
     <value>インクリメント演算子またはデクリメント演算子のオペランドには、変数、プロパティ、またはインデクサーを指定してください。</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>/embed スイッチは、ポータブル PDB の生成時にのみサポートされます (/debug:portable または /debug:embedded)。</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>'{0}' に extern と abstract の両方を指定することはできません。</value>
@@ -3111,8 +3135,8 @@ C# では out と ref を区別しますが、CLR では同じと認識します
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>'{0}' と '{1}' 間があいまいです</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>メソッド、クラス、構造体、またはインターフェイスのみが partial を宣言できます</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>コマンドラインの構文エラー: オプション '{1}' の GUID がありません。</value>
@@ -3191,145 +3215,146 @@ C# では out と ref を区別しますが、CLR では同じと認識します
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Visual C# Compiler のオプション
+                              Visual C# Compiler Options
 
-                        - 出力ファイル -
- /out:&lt;file&gt;                   出力ファイル名を指定します (既定: メイン クラス
-                               のあるファイルまたは最初のファイルのベース名)
- /target:exe                   コンソール実行可能ファイルをビルドします (既定) (短い 
-                               形式: /t:exe)
- /target:winexe                Windows 実行可能ファイルをビルドします (短い形式: 
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               ライブラリをビルドします (短い形式: /t:library)
- /target:module                別のアセンブリに追加できるモジュールをビルド 
-                               します (短い形式: /t:module)
- /target:appcontainerexe       Appcontainer 実行可能ファイルをビルドします (短い形式: 
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              WinMDExp で使用される 
-                               Windows ランタイムの中間ファイルをビルドします (短い形式: /t:winmdobj)
- /doc:&lt;file&gt;                   生成する XML ドキュメント ファイル
- /refout:&lt;file&gt;                生成する参照アセンブリ出力
- /platform:&lt;string&gt;            このコードを実行できるプラットフォームを x86、
-                               Itanium、x64、arm、anycpu32bitpreferred、
-                               anycpu に制限します。既定は anycpu です。
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        - 入力ファイル -
- /recurse:&lt;wildcard&gt;           ワイルドカードの指定に従い、現行ディレクトリおよび 
-                               サブディレクトリ内のすべてのファイルを 
-                               インクルードします
- /reference:&lt;alias&gt;=&lt;file&gt;     指定されたエイリアスを使用して、指定された 
-                               アセンブリ ファイルのメタデータを参照します (短い形式: /r)
- /reference:&lt;file list&gt;        指定されたアセンブリ ファイルのメタデータを参照 
-                               します (短い形式: /r)
- /addmodule:&lt;file list&gt;        指定されたモジュールをこのアセンブリにリンクします
- /link:&lt;file list&gt;             指定された相互運用アセンブリ ファイルのメタデータを
-                               埋め込みます (短い形式: /l)
- /analyzer:&lt;file list&gt;         このアセンブリからアナライザーを実行します
-                               (短い形式: /a)
- /additionalfile:&lt;file list&gt;   コード生成には直接影響しないものの、
-                               アナライザーがエラーまたは警告を
-                               生成するときに使用する可能性のある追加ファイル。
- /embed                        すべてのソース ファイルを PDB に埋め込みます。
- /embed:&lt;file list&gt;            特定のファイルを PDB に埋め込みます
- 
-                        - リソース -
- /win32res:&lt;file&gt;              Win32 リソース ファイル (.res) を指定します
- /win32icon:&lt;file&gt;             出力にこのアイコンを使用します
- /win32manifest:&lt;file&gt;         Win32 マニフェスト ファイル (.xml) を指定します
- /nowin32manifest              既定の Win32 マニフェストはインクルードしません
- /resource:&lt;resinfo&gt;           指定されたリソースを埋め込みます (短い形式: /res)
- /linkresource:&lt;resinfo&gt;       指定されたリソースをこのアセンブリにリンクします 
-                               (短い形式: /linkres) ここで resinfo の形式 
-                               は &lt;file&gt;[,&lt;string name&gt;[,public|private]] です
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        - コード生成 -
- /debug[+|-]                   デバッグ情報を生成します
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
+
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               デバッグの種類を指定します ('full' が既定です。
-                               'portable' はクロスプラットフォーム形式です。
-                               'embedded' は、ターゲット .dll または .exe に
-                               埋め込まれるクロスプラットフォーム形式です)
- /optimize[+|-]                最適化を有効にします (短い形式: /o)
- /deterministic                決定論的アセンブリを作成します
-                               (モジュール バージョン GUID やタイムスタンプなど)
- /refonly                      メイン出力の代わりに参照アセンブリを生成します
- /instrument:TestCoverage      収集するためのインストルメント化されたアセンブリを作成します
-                               カバレッジ情報
- /sourcelink:&lt;file&gt;            ポータブル PDB に埋め込むソース リンク情報。
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        - エラーと警告 -
- /warnaserror[+|-]             すべての警告をエラーとして報告します
- /warnaserror[+|-]:&lt;warn list&gt; 特定の警告をエラーとして報告します
- /warn:&lt;n&gt;                     警告レベル (0-4) を設定します (短い形式: /w)
- /nowarn:&lt;warn list&gt;           特定の警告メッセージを無効にします
- /ruleset:&lt;file&gt;               特定の診断を無効にするルールセット ファイルを
-                               指定します。
- /errorlog:&lt;file&gt;              すべてのコンパイラとアナライザーの診断をログに記録するための
-                               ファイルを指定します。
- /reportanalyzer               追加のアナライザー情報を報告します
-                               (実行時間など)。
- 
-                        - 言語 -
- /checked[+|-]                 オーバーフロー検査を生成します
- /unsafe[+|-]                  '安全でない' コードを許可します
- /define:&lt;symbol list&gt;         条件付きコンパイル シンボルを定義します (短い 
-                               形式: /d)
- /langversion:&lt;string&gt;         言語バージョン モードを指定します: ISO-1、ISO-2、3、
-                               4、5、6、7、7.1、既定、最新
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        - セキュリティ -
- /delaysign[+|-]               厳密な名前のキーのパブリックな部分のみを使って 
-                               アセンブリを遅延署名します
- /publicsign[+|-]              厳密な名前のキーのパブリックな部分のみを使って
-                               アセンブリを公開署名します
- /keyfile:&lt;file&gt;               厳密な名前キーのファイルを指定します
- /keycontainer:&lt;string&gt;        厳密な名前キーのコンテナーを指定します
- /highentropyva[+|-]           高エントロピ ASLR を有効化します
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        - その他 -
- @&lt;file&gt;                       応答ファイルを読み込み、オプションを追加します
- /help                         使用法に関するメッセージを表示します (短い形式: /?)
- /nologo                       コンパイル時の著作権メッセージを表示しません
- /noconfig                     CSC.RSP ファイルを自動的に含めません
- /parallel[+|-]                ビルドを並列処理します。 
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-/version                      コンパイラのバージョン番号を出力して終了します。
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
 
-                        - 詳細 -
- /baseaddress:&lt;address&gt;        ビルドするライブラリのベース アドレス
- /bugreport:&lt;file&gt;             'バグ報告' ファイルを作成します
- /checksumalgorithm:&lt;alg&gt;      PDB に格納されているソース ファイルのチェックサム 
-                               を計算するアルゴリズムを指定します。サポートされる値:
-                               SHA1 (既定) または SHA256。
- /codepage:&lt;n&gt;                 ソース ファイルを開くときに使用するコード ページを 
-                               指定します
- /utf8output                   コンパイラ メッセージを UTF-8 エンコードで出力します
- /main:&lt;type&gt;                  エントリ ポイントを含む型を指定します 
-                               (他のエントリ ポイントはすべて無視します) (短い 
-                               形式: /m)
- /fullpaths                    コンパイラは完全修飾パスを生成します
- /filealign:&lt;n&gt;                出力ファイル セクションで使用する配置を指定 
-                               します
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
  /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                               コンパイラが出力するソース パス名のマッピングを
-                               指定します。
- /pdb:&lt;file&gt;                   デバッグ情報ファイル名を指定します (既定: 
-                               .pdb 拡張子の付いた出力ファイル名)
- /errorendlocation             各エラーの終了位置の出力行と 
-                               出力列
- /preferreduilang              出力用の言語名を指定します。
- /nostdlib[+|-]                標準ライブラリ (mscorlib.dll) は参照しません
- /subsystemversion:&lt;string&gt;    このアセンブリのサブシステム バージョンを指定します
- /lib:&lt;file list&gt;              参照を検索する追加ディレクトリを指定 
-                               します
- /errorreport:&lt;string&gt;         内部コンパイラ エラーの処理方法を指定します: 
-                               prompt、send、queue、none です。既定値は 
-                               queue です。
- /appconfig:&lt;file&gt;             アセンブリ バインド設定を含む 
-                               アプリケーション構成ファイルを指定します
- /moduleassemblyname:&lt;string&gt;  このモジュールが一部となるアセンブリ名 
-                               です
- /modulename:&lt;string&gt;          ソース モジュールの名前を指定します
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
+                               queue.
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3639,7 +3664,7 @@ C# では out と ref を区別しますが、CLR では同じと認識します
     <value>型 '{0}' を型 '{1}' に変換する標準変換が存在しないため、CallerMemberNameAttribute を適用することはできません。</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>ref パラメーターでも out パラメーターでもないため、パラメーター '{0}' のメンバーを参照渡しで返すことはできません</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(以前のエラーに関連するシンボルの位置)</value>
@@ -3684,7 +3709,7 @@ C# では out と ref を区別しますが、CLR では同じと認識します
     <value>ref パラメーターでも out パラメーターでもないため、パラメーターを参照 '{0}' 渡しで返すことはできません</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>名前空間で定義された要素は明示的に private、protected、または protected internal に宣言することはできません。</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>/moduleassemblyname オプションは 'module' のターゲット型をビルドするときのみ指定できます。</value>
@@ -3853,6 +3878,9 @@ C# では out と ref を区別しますが、CLR では同じと認識します
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>'{0}' は演算子 == または演算子 != を定義しますが、Object.GetHashCode() をオーバーライドしません。</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>バイナリ演算子のパラメーターの 1 つはそれを含む型でなければなりません。</value>
@@ -4317,7 +4345,7 @@ C# では out と ref を区別しますが、CLR では同じと認識します
     <value>型パラメーター '{1}' は 'struct' 制約を含むので、'{0}' の制約として '{1}' を使用することはできません</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>定義済みの型 '{0}' は定義、またはインポートされていません</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>型引数を null にすることはできません。</value>
@@ -4482,7 +4510,7 @@ C# では out と ref を区別しますが、CLR では同じと認識します
     <value>引数 {0}: は '{1}' から '{2}' へ変換することはできません。</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>名前付き引数は、すべての固定引数を指定した後で指定する必要があります</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>メソッド '{1}' の型パラメーター '{0}' に対する制約は、インターフェイス メソッド '{3}' の型パラメーター '{2}' に対する制約と一致しなければなりません。明示的なインターフェイスの実装を使用することをお勧めします。</value>
@@ -5062,6 +5090,9 @@ C# では out と ref を区別しますが、CLR では同じと認識します
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>式のようなインデクサー</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>'{0}': 動的な型から派生することはできません。</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.ko.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.ko.resx
@@ -380,6 +380,9 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>CLS 규격 멤버만 abstract일 수 있습니다.</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>어셈블리 및 '{0}' 모듈은 다른 프로세서를 대상으로 할 수 없습니다.</value>
   </data>
@@ -468,7 +471,7 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
     <value>'{0}'이(가) '{1}' 패턴을 구현하지 않습니다. '{2}'이(가) '{3}'에서 모호합니다.</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>/langversion에 대한 '{0}' 옵션이 잘못되었습니다. ISO-1, ISO-2, Default, Latest 또는 1에서 7.1 사이의 유효한 버전이어야 합니다.</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>정규화된 별칭 이름은 식이 아닙니다.</value>
@@ -713,6 +716,9 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>부동 소수점 상수가 '{0}' 형식 범위 밖에 있습니다.</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>인코딩하지 않고 원본 텍스트에 대한 디버그 정보를 생성할 수 없습니다.</value>
   </data>
@@ -733,6 +739,9 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>'{0}' 요소에 대한 끝 태그가 필요합니다.</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>nameof 연산자에서는 형식 인수가 허용되지 않습니다.</value>
@@ -872,11 +881,14 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>'{1}' 어셈블리의 '{0}' 형식에 포함된 interop 형식인 제네릭 형식 인수가 있기 때문에 이 형식을 다른 어셈블리에서 사용할 수 없습니다.</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>as 연산자는 참조 형식 또는 null 허용 형식과 함께 사용해야 합니다. '{0}'은(는) null을 허용하지 않는 값 형식입니다.</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>'{0}' 추상 메서드는 virtual로 표시할 수 없습니다.</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>'{0}': 정적 클래스는 사용자 정의 연산자를 포함할 수 없습니다.</value>
@@ -1028,6 +1040,9 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>필터 식이 상수이므로 필터에서 제거하세요.</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>'{0}' 기능은 C# 7.1에서 사용할 수 없습니다. {1} 이상의 언어 버전을 사용하세요.</value>
   </data>
@@ -1109,6 +1124,9 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>'{0}' 멤버는 액세스 가능한 멤버를 숨기지 않으므로 new 키워드가 필요하지 않습니다.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>#pragma 경고 전처리기 지시문에 전달된 번호는 올바른 경고 번호가 아닙니다. 번호가 오류가 아닌 경고를 나타내는지 확인하세요.</value>
   </data>
@@ -1126,6 +1144,9 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>#r은 스크립트에서만 허용됩니다.</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>구문 트리가 이미 있습니다.</value>
@@ -1322,6 +1343,9 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>잘못된 참조 별칭 옵션입니다. '{0}=' -- 파일 이름이 없습니다.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>읽기 전용 필드 '{0}'의 멤버는 참조로 반환될 수 없습니다.</value>
   </data>
@@ -1347,7 +1371,7 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
     <value>Windows Runtime 이벤트를 out 또는 ref 매개 변수로 전달할 수 없습니다.</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>'{0}' 형식의 인스턴스는 익명 함수, 쿼리 식, 반복기 블록 또는 비동기 메서드 내에서 사용할 수 없습니다.</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>'{0}'은(는) '{1}' 인터페이스 멤버를 구현하지 않습니다. '{2}'에 일치하는 반환 형식 '{3}'이(가) 없으므로 '{1}'을(를) 구현할 수 없습니다.</value>
@@ -1828,7 +1852,7 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
     <value>증가 연산자 또는 감소 연산자의 피연산자는 변수, 속성 또는 인덱서여야 합니다.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>/embed 스위치는 이식 가능한 PDB를 내보낼 때만 지원됩니다(/debug:portable 또는 /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>'{0}'은(는) extern 및 abstract일 수 없습니다.</value>
@@ -3111,8 +3135,8 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>'{0}'과(와) '{1}' 사이에 모호성이 있습니다.</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>메서드, 클래스, 구조체 또는 인터페이스만 partial일 수 있습니다.</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>명령줄 구문 오류: '{1}' 옵션에 대한 Guid가 없습니다.</value>
@@ -3191,143 +3215,146 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Visual C# 컴파일러 옵션
+                              Visual C# Compiler Options
 
-                        - 출력 파일 -
- /out:&lt;file&gt;                   출력 파일 이름을 지정합니다(기본값: 주 클래스가 
-                               있는 파일 또는 첫째 파일의 기본 이름).
- /target:exe                   콘솔 실행 파일을 빌드합니다(기본값). (약식
-                               : /t:exe)
- /target:winexe                Windows 실행 파일을 빌드합니다. (약식: 
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               라이브러리를 빌드합니다. (약식: /t:library)
- /target:module                다른 어셈블리에 추가될 수 있는 모듈을 
-                               빌드합니다. (약식: /t:module)
- /target:appcontainerexe       Appcontainer 실행 파일을 빌드합니다. (약식: 
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              WinMDExp에서 사용되는 Windows 런타임 중간 
-                               파일을 빌드합니다. (약식: /t:winmdobj)
- /doc:&lt;file&gt;                   생성할 XML 문서 파일
- /refout:&lt;file&gt;                생성할 참조 어셈블리 출력
- /platform:&lt;string&gt;            이 코드를 실행할 수 있는 플랫폼을 x86,
-                               Itanium, x64, arm, anycpu32bitpreferred 또는 
-                               anycpu로 제한합니다. 기본값은 anycpu입니다.
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        - 입력 파일 -
- /recurse:&lt;wildcard&gt;           와일드카드 지정에 따라 현재 디렉터리와 
-                               하위 디렉터리에 있는 모든 파일을 
-                               포함합니다.
- /reference:&lt;alias&gt;=&lt;file&gt;     지정한 어셈블리 파일에서 해당 별칭을 사용하여 
-                               메타데이터를 참조합니다. (약식: /r)
- /reference:&lt;file list&gt;        지정한 어셈블리 파일에서 메타데이터를 
-                               참조합니다. (약식: /r)
- /addmodule:&lt;file list&gt;        지정한 모듈을 이 어셈블리에 링크합니다.
- /link:&lt;file list&gt;             지정된 interop 어셈블리 파일의 메타데이터를 
-                               포함합니다. (약식: /l)
- /analyzer:&lt;file list&gt;         이 어셈블리에서 분석기를 실행합니다.
-                               (약식: /a)
- /additionalfile:&lt;file list&gt;   코드 생성에 직접 영향을 주지 않지만 오류 또는
-                               경고 생성을 위해 분석기에서 사용될 수 있는
-                               추가 파일입니다.
- /embed                        모든 소스 파일을 PDB에 포함합니다.
- /embed:&lt;file list&gt;            특정 파일을 PDB에 포함합니다.
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        - 리소스 -
- /win32res:&lt;file&gt;              Win32 리소스 파일(.res)을 지정합니다.
- /win32icon:&lt;file&gt;             이 아이콘을 사용하여 출력합니다.
- /win32manifest:&lt;file&gt;         Win32 매니페스트 파일(.xml)을 지정합니다.
- /nowin32manifest              기본 Win32 매니페스트는 포함하지 않습니다.
- /resource:&lt;resinfo&gt;           지정된 리소스를 포함합니다. (약식: /res)
- /linkresource:&lt;resinfo&gt;       지정한 리소스를 이 어셈블리에 링크합니다. 
-                               (약식: /linkres) resinfo 형식이 
-                              &lt;file&gt;[,&lt;string name&gt;[,public|private]]인 경우
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        - 코드 생성 -
- /debug[+|-]                   디버깅 정보를 내보냅니다.
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               디버깅 형식을 지정합니다. ('full'이 기본값이고, 
-                               'portable'은 크로스 플랫폼 형식이고,
-                               'embedded'는 대상 .dll 또는 .exe에 포함되는 
-                               크로스 플랫폼 형식입니다.)
- /optimize[+|-]                최적화를 사용합니다. (약식: /o)
- /deterministic                결정적 어셈블리를 생성합니다.
-                               (모듈 버전 GUID 및 타임스탬프 포함)
- /refonly                      주 출력 대신 참조 어셈블리 생성
- /instrument:TestCoverage           검사 정보를 수집하기 위해 계측한
-                               어셈블리를 생성합니다.
- /sourcelink:&lt;file&gt;            이식 가능한 PDB에 포함할 소스 링크 정보입니다.
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        - 오류 및 경고 -
- /warnaserror[+|-]             모든 경고를 오류로 보고합니다.
- /warnaserror[+|-]:&lt;warn list&gt; 특정 경고를 오류로 보고합니다.
- /warn:&lt;n&gt;                     경고 수준(0-4)을 설정합니다. (약식: /w)
- /nowarn:&lt;warn list&gt;           특정 경고 메시지를 사용하지 않습니다.
- /ruleset:&lt;file&gt;               특정 진단을 사용하지 않도록 하는 규칙 집합
-                               파일을 지정합니다.
- /errorlog:&lt;file&gt;              모든 컴파일러 및 분석기 진단을 기록할 파일을
-                               지정합니다.
- /reportanalyzer               추가 분석기 정보(예: 실행 시간)를
-                               보고합니다.
- 
-                        - 언어 -
- /checked[+|-]                 오버플로 검사를 생성합니다.
- /unsafe[+|-]                  'unsafe' 코드를 사용할 수 있습니다.
- /define:&lt;symbol list&gt;         조건부 컴파일 기호를 정의합니다. (약식 
-                               : /d)
- /langversion:&lt;string&gt;         언어 버전 모드를 ISO-1, ISO-2, 3, 
-                               4, 5, 6, 7, 7.1, Default 또는 Latest로 지정합니다.
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        - 보안 -
- /delaysign[+|-]               강력한 이름 키의 공개 부분만 사용하여 
-                               어셈블리 서명을 연기합니다.
- /publicsign[+|-]              강력한 이름 키의 공개 부분만 사용하여 어셈블리를
-                               공개 서명합니다.
- /keyfile:&lt;file&gt;               강력한 이름의 키 파일을 지정합니다.
- /keycontainer:&lt;string&gt;        강력한 이름의 키 컨테이너를 지정합니다.
- /highentropyva[+|-]           높은 엔트로피 ASLR을 사용합니다.
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        - 기타 -
- @&lt;file&gt;                       추가 옵션에 대한 지시 파일을 읽습니다.
- /help                         사용법 메시지를 표시합니다. (약식: /?)
- /nologo                       컴파일러 저작권 메시지를 표시하지 않습니다.
- /noconfig                     CSC.RSP 파일을 자동으로 포함하지 않습니다.
- /parallel[+|-]                동시 빌드.
- /version                      컴파일러 버전 번호를 표시하고 종료합니다. 
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        - 고급 -
- /baseaddress:&lt;address&gt;        빌드할 라이브러리의 기준 주소
- /checksumalgorithm:&lt;alg&gt;      PDB에 저장된 소스 파일 체크섬을 
-                               계산하기 위한 알고리즘을 지정합니다. 지원되는 값은
-                               SHA1(기본값) 또는 SHA256입니다.
- /codepage:&lt;n&gt;                 소스 파일을 열 때 사용할 코드 페이지를 
-                               지정합니다.
- /utf8output                   컴파일러 메시지를 UTF-8 인코딩으로 출력합니다.
- /main:&lt;type&gt;                  진입점을 포함하는 형식을 지정합니다. 
-                               다른 모든 가능한 진입점은 무시합니다. (약식 
-                               : /m)
- /fullpaths                    컴파일러가 정규화된 경로를 생성합니다.
- /filealign:&lt;n&gt;                출력 파일 섹션에 사용되는 맞춤을 
-                               지정합니다.
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
+
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
  /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                               컴파일러에서 소스 경로 이름 출력에 대한
-                               매핑을 지정합니다.
- /pdb:&lt;file&gt;                   디버그 정보 파일 이름을 지정합니다(기본값: 
-                               확장명이 .pdb인 출력 파일 이름).
- /errorendlocation             각 오류의 끝 위치에 해당하는 줄과 
-                               열 출력
- /preferreduilang              기본 출력 언어 이름을 지정합니다.
- /nostdlib[+|-]                표준 라이브러리(mscorlib.dll)를 참조하지 않습니다.
- /subsystemversion:&lt;string&gt;    이 어셈블리의 하위 시스템 버전을 지정합니다.
- /lib:&lt;file list&gt;              참조를 검색할 추가 디렉터리를 
-                               지정합니다.
- /errorreport:&lt;string&gt;         내부 컴파일러 오류를 처리하는 방법을 지정합니다. 
-                               prompt, send, queue 또는 none 중에서 선택할 수 있으며 기본값은
-                               queue입니다.
- /appconfig:&lt;file&gt;             어셈블리 바인딩 설정을 포함하는 
-                               응용 프로그램 구성 파일을 지정합니다.
- /moduleassemblyname:&lt;string&gt;  이 모듈이 속할 어셈블리의 
-                               이름입니다.
- /modulename:&lt;string&gt;          소스 모듈의 이름을 지정합니다.
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
+                               queue.
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3637,7 +3664,7 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
     <value>'{0}' 형식에서 '{1}' 형식으로의 표준 변환이 없기 때문에 CallerMemberNameAttribute를 적용할 수 없습니다.</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>'{0}' 매개 변수의 멤버는 ref 또는 out 매개 변수가 아니므로 참조로 반환할 수 없습니다.</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(이전 오류와 관련된 기호 위치)</value>
@@ -3682,7 +3709,7 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
     <value>'{0}' 매개 변수는 ref 또는 out 매개 변수가 아니므로 참조로 반환할 수 없습니다.</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>네임스페이스에 정의된 요소는 명시적으로 private, protected 또는 protected internal로 선언할 수 없습니다.</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>/moduleassemblyname 옵션은 빌드하는 대상 형식이 'module'인 경우에만 지정할 수 있습니다.</value>
@@ -3851,6 +3878,9 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>'{0}'은(는) == 연산자 또는 != 연산자를 정의하지만 Object.GetHashCode()를 재정의하지 않습니다.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>이항 연산자의 매개 변수 중 하나는 포함하는 형식이어야 합니다.</value>
@@ -4315,7 +4345,7 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
     <value>형식 매개 변수 '{1}'에 'struct' 제약 조건이 있으므로 '{1}'은(는) '{0}'에 대한 제약 조건으로 사용할 수 없습니다.</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>미리 정의된 형식 '{0}'을(를) 정의하지 않았거나 가져오지 않았습니다.</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>형식 인수는 null일 수 없습니다.</value>
@@ -4480,7 +4510,7 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
     <value>{0} 인수: '{1}'에서 '{2}'(으)로 변환할 수 없습니다.</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>명명된 인수 사양은 모든 고정 인수를 지정한 다음에 와야 합니다.</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>'{1}' 메서드의 '{0}' 형식 매개 변수에 대한 제약 조건이 '{3}' 인터페이스 메서드의 '{2}' 형식 매개 변수에 대한 제약 조건과 일치해야 합니다. 명시적 인터페이스 구현을 대신 사용하세요.</value>
@@ -5060,6 +5090,9 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>식 본문 인덱서</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>'{0}': 동적 유형에서 파생될 수 없습니다.</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.pl.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.pl.resx
@@ -380,6 +380,9 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>Tylko elementy członkowskie zgodne ze specyfikacją CLS mogą być abstrakcyjne</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>Zestaw i moduł „{0}” nie mogą wskazywać różnych procesorów.</value>
   </data>
@@ -468,7 +471,7 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
     <value>Element „{0}” nie implementuje wzorca „{1}”. Elementy „{2}” i „{3}” są wzajemnie niejednoznaczne.</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>Nieprawidłowa opcja „{0}” dla parametru /langversion; musi to być ISO-1, ISO-2, Default, Latest lub prawidłowa wersja w zakresie od 1 do 7.1.</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>Nazwa kwalifikowana za pomocą aliasu nie jest wyrażeniem.</value>
@@ -713,6 +716,9 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>Wartość stałej zmiennoprzecinkowej jest spoza zakresu typu „{0}”</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>Nie można wyemitować informacji debugowania dla tekstu źródłowego bez kodowania.</value>
   </data>
@@ -733,6 +739,9 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>Oczekiwano tagu końcowego dla elementu „{0}”.</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>Argumenty typu nie są dozwolone w operatorze nameof.</value>
@@ -872,11 +881,14 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>Typ „{0}” z zestawu „{1}” nie może być używany między granicami zestawów, ponieważ ma argument typu ogólnego, który jest osadzonym typem międzyoperacyjnym.</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>Operatora „as” należy używać z typem referencyjnym lub typem dopuszczającym wartość null („{0}” jest typem niedopuszczającym wartości null)</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>Abstrakcyjna metoda „{0}” nie może być oznaczona jako wirtualna</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>„{0}”: klasy statyczne nie mogą zawierać operatorów zdefiniowanych przez użytkownika</value>
@@ -1028,6 +1040,9 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>Wyrażenie filtru jest stałą, rozważ usunięcie filtru</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>Funkcja „{0}” nie jest dostępna w języku C# 7.1. Użyj języka w wersji {1} lub nowszej.</value>
   </data>
@@ -1109,6 +1124,9 @@ Pominięcie ostrzeżenia należy wziąć pod uwagę tylko w sytuacji, gdy na pew
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>Element członkowski „{0}” nie ukrywa elementu członkowskiego z możliwością dostępu. Słowo kluczowe new nie jest wymagane.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>Numer przekazany do dyrektywy preprocesora ostrzeżenia #pragma nie jest prawidłowym numerem ostrzeżenia. Upewnij się, że numer reprezentuje ostrzeżenie, a nie błąd.</value>
   </data>
@@ -1126,6 +1144,9 @@ Pominięcie ostrzeżenia należy wziąć pod uwagę tylko w sytuacji, gdy na pew
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>Dyrektywa #r jest dozwolona tylko w skryptach</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>Drzewo składni już istnieje</value>
@@ -1322,6 +1343,9 @@ Pominięcie ostrzeżenia należy wziąć pod uwagę tylko w sytuacji, gdy na pew
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>Nieprawidłowa opcja aliasu odwołania: „{0}=” — brak nazwy pliku</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>Elementów członkowskich pola tylko do odczytu „{0}” nie można zwrócić przed odwołanie</value>
   </data>
@@ -1347,7 +1371,7 @@ Pominięcie ostrzeżenia należy wziąć pod uwagę tylko w sytuacji, gdy na pew
     <value>Zdarzenia środowiska wykonawczego systemu Windows nie można przekazać jako parametru ze specyfikatorem out lub ref.</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>Wystąpienia typu „{0}” nie można użyć wewnątrz funkcji anonimowej, wyrażenia zapytania, bloku iteratora ani metody asynchronicznej</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>Element „{0}” nie implementuje elementu członkowskiego interfejsu „{1}”. Element „{2}” nie może implementować elementu „{1}”, ponieważ brak pasującego zwracanego typu „{3}”.</value>
@@ -1828,7 +1852,7 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
     <value>Argument operatora zwiększania lub zmniejszania musi być zmienną, właściwością lub indeksatorem.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Przełącznik /embed jest obsługiwany tylko w przypadku emitowania przenośnego pliku PDB (/debug:portable lub /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>Element „{0}” nie może być zewnętrzny i abstrakcyjny</value>
@@ -3111,8 +3135,8 @@ Jeśli taka klasa zostanie użyta jako klasa podstawowa i klasa pochodna definiu
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>Niejednoznaczność pomiędzy „{0}” i „{1}”</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>Tylko metody, klasy, struktury i interfejsy mogą być częściowe.</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>Błąd składni wiersza polecenia: brak identyfikatora Guid dla opcji „{1}”</value>
@@ -3191,143 +3215,146 @@ Jeśli taka klasa zostanie użyta jako klasa podstawowa i klasa pochodna definiu
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Opcje kompilatora Visual C#
+                              Visual C# Compiler Options
 
-                        - PLIKI WYJŚCIOWE -
- /out:&lt;plik&gt;                   Określ nazwę pliku wyjściowego (domyślnie: nazwa podstawowa 
-                               pliku z klasą główną lub pierwszym plikiem)
- /target:exe                   Kompiluj plik wykonywalny konsoli (domyślnie) (krótka 
-                               wersja: /t:exe)
- /target:winexe                Kompiluj plik wykonywalny systemu Windows (krótka wersja: 
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               Kompiluj bibliotekę (krótka wersja: /t:library)
- /target:module                Kompiluj moduł, który można dodać do innego 
-                               zestawu (krótka wersja: /t:module)
- /target:appcontainerexe       Kompiluj plik wykonywalny kontenera aplikacji (krótka wersja: 
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              Kompiluj plik pośredni środowiska uruchomieniowego systemu Windows 
-                               przeznaczony dla narzędzia WinMDExp (krótka wersja: /t:winmdobj)
- /doc:&lt;plik&gt;                   Plik dokumentacji XML do wygenerowania
- /refout:&lt;plik&gt;                Dane wyjściowe zestawu odwołania do wygenerowania
-  /platform:&lt;ciąg&gt;              Ogranicz platformy, na których można uruchamiać ten kod: x86,
-                               Itanium, x64, arm, anycpu32bitpreferred lub 
-                               anycpu. Wartość domyślna to anycpu.
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        - PLIKI WEJŚCIOWE -
- /recurse:&lt;symbol wieloznaczny&gt; Dołącz wszystkie pliki zawarte w bieżącym katalogu i 
-                               jego podkatalogach zgodnie ze specyfikacją określoną przy użyciu 
-                               symboli wieloznacznych
- /reference:&lt;alias&gt;=&lt;plik&gt;     Odwołuj się do metadanych z określonego pliku 
-                               zestawu przy użyciu podanego aliasu (krótka wersja: /r)
- /reference:&lt;lista plików&gt;     Odwołuj się do metadanych z określonych 
-                               plików zestawów (krótka wersja: /r)
- /addmodule:&lt;lista plików&gt;     Połącz określone moduły z tym zestawem
- /link:&lt;lista plików&gt;          Osadź metadane z określonych plików 
-                               zestawów międzyoperacyjnych (krótka wersja: /l)
- /analyzer:&lt;lista plików&gt;      Uruchom analizatory z tego zestawu
-                               (krótka wersja: /a)
- /additionalfile:&lt;lista plików&gt; Dodatkowe pliki, które nie mają bezpośredniego wpływu na generowanie
-                               kodu, ale mogą być używane przez analizatory w celu tworzenia
-                               komunikatów o błędach lub ostrzeżeń.
- /embed                        Osadź wszystkie pliki źródłowe w pliku PDB.
- /embed:&lt;lista plików&gt;            Osadź określone pliki w pliku PDB
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        - ZASOBY -
- /win32res:&lt;plik&gt;              Określ plik zasobu Win32 (res)
- /win32icon:&lt;plik&gt;             Użyj tej ikony dla pliku wyjściowego
- /win32manifest:&lt;plik&gt;         Określ plik manifestu środowiska Win32 (xml)
- /nowin32manifest              Nie dołączaj domyślnego manifestu środowiska Win32
- /resource:&lt;informacje o zasobie&gt; Osadź określony zasób (krótka wersja: /res)
- /linkresource:&lt;informacje o zasobie&gt; Połącz określony zasób z tym zestawem 
-                               (krótka wersja: /linkres), gdzie format informacji o zasobie 
-                               to &lt;plik&gt;[,&lt;nazwa ciągu&gt;[,public|private]]
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        - GENEROWANIE KODU -
- /debug[+|-]                   Emituj informacje o debugowaniu
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               Określ typ debugowania (wartość domyślna to „full”, 
-                               wartość „portable” to format międzyplatformowy,
-                               a wartość „embedded” to format międzyplatformowy wbudowany w 
-                               docelowym pliku DLL lub EXE)
- /optimize[+|-]                Włącz optymalizacje (krótka wersja: /o)
- /deterministic                Utwórz zestaw deterministyczny
-                               (w tym sygnaturę czasową i identyfikator GUID wersji modułu)
- /refonly                      Utwórz zestaw odwołania zamiast głównych danych wyjściowych
-  /instrument:TestCoverage      Utwórz zestaw instrumentowany w celu gromadzenia
-                               informacji o pokryciu
- /sourcelink:&lt;plik&gt;            Informacje o linku źródłowym na potrzeby osadzenia w pliku PDB.
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        - BŁĘDY I OSTRZEŻENIA -
- /warnaserror[+|-]             Zgłaszaj wszystkie ostrzeżenia jako błędy
- /warnaserror[+|-]:&lt;lista ostrzeżeń&gt; Zgłaszaj określone ostrzeżenia jako błędy
- /warn:&lt;n&gt;                     Ustaw poziom ostrzeżenia (0–4) (krótka wersja: /w)
- /nowarn:&lt;lista ostrzeżeń&gt;     Wyłącz określone komunikaty ostrzeżeń
- /ruleset:&lt;plik&gt;               Określ plik zestawu reguł wyłączający określone
-                               funkcje diagnostyczne.
- /errorlog:&lt;plik&gt;              Określ plik, w którym mają zostać zarejestrowane dane diagnostyczne
-                               wszystkich kompilatorów i analizatorów.
- /reportanalyzer               Zgłaszaj dodatkowe informacje analizatora, takie jak
-                               czas wykonywania.
- 
-                        -JĘZYK -
- /checked[+|-]                 Generuj operacje sprawdzenia przepełnienia
- /unsafe[+|-]                  Zezwalaj na niebezpieczny kod
- /define:&lt;lista symboli&gt;       Definiuj symbole kompilacji warunkowej (krótka 
-                               wersja: /d)
- /langversion:&lt;ciąg&gt;           Określ tryb wersji języka: ISO-1, ISO-2, 3, 
-                               4, 5, 6, 7, 7.1, Default lub Latest
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        - ZABEZPIECZENIA -
- /delaysign[+|-]               Podpisz z opóźnieniem zestaw, używając tylko 
-                               części publicznej klucza o silnej nazwie
- /publicsign[+|-]              Podpisz publicznie zestaw, używając tylko
-                               części publicznej klucza o silnej nazwie
- /keyfile:&lt;plik&gt;               Określ plik klucza o silnej nazwie
- /keycontainer:&lt;ciąg&gt;          Określ kontener klucza o silnej nazwie
- /highentropyva[+|-]           Włącz losowe generowanie układu przestrzeni adresowej o wysokiej entropii
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        - RÓŻNE -
- @&lt;plik&gt;                       Odczytaj plik odpowiedzi w celu uzyskania dodatkowych opcji
- /help                         Wyświetl ten komunikat dotyczący użycia (krótka wersja: /?)
- /nologo                       Pomiń komunikat kompilatora o prawach autorskich
- /noconfig                     Nie dołączaj automatycznie pliku CSC.RSP
- /parallel[+|-]                Współbieżna kompilacja.
- /version                      Wyświetl numer wersji kompilatora i wyjdź.
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        - ZAAWANSOWANE -
- /baseaddress:&lt;adres&gt;          Adres podstawowy dla biblioteki do skompilowania
- /checksumalgorithm:&lt;algorytm&gt; Określ algorytm do obliczania sumy kontrolnej
-                               pliku źródłowego przechowywanej w pliku PDB. Obsługiwane są następujące wartości:
-                               SHA1 (domyślnie) lub SHA256.
- /codepage:&lt;n&gt;                 Określ stronę kodową do użycia podczas otwierania 
-                               plików źródłowych
- /utf8output                   Wyprowadź komunikaty kompilatora przy użyciu kodowania UTF-8
- /main:&lt;typ&gt;                   Określ typ zawierający punkt wejścia 
-                               (wszystkie pozostałe możliwe punkty wejścia zostaną zignorowane) (krótka 
-                               wersja: /m)
- /fullpaths                    Kompilator generuje w pełni kwalifikowane ścieżki
- /filealign:&lt;n&gt;                Określ wyrównanie stosowane dla sekcji 
-                               plików wyjściowych
- /pathmap:&lt;K1&gt;=&lt;W1&gt;,&lt;K2&gt;=&lt;W2&gt;,... 
-                               Określ mapowanie dla nazw ścieżek źródłowych wyprowadzanych przez 
-                               kompilator.
- /pdb:&lt;plik&gt;                   Określ nazwę pliku z informacjami o debugowaniu (domyślnie: 
-                               nazwa pliku wyjściowego z rozszerzeniem pdb)
- /errorendlocation             Wyprowadź wiersz i kolumnę lokalizacji końcowej dla 
-                               każdego błędu
- /preferreduilang              Określ nazwę preferowanego języka wyjściowego.
- /nostdlib[+|-]                Nie odwołuj się do biblioteki standardowej (mscorlib.dll)
- /subsystemversion:&lt;ciąg&gt;      Określ wersję podsystemu tego zestawu
- /lib:&lt;lista plików&gt;           Określ dodatkowe katalogi do przeszukania pod kątem 
-                               odwołań
- /errorreport:&lt;ciąg&gt;           Określ, w jaki sposób obsługiwać wewnętrzne błędy kompilatora: 
-                               prompt, send, queue lub none. Wartość domyślna to 
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
+
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
+ /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
                                queue.
- /appconfig:&lt;plik&gt;             Określ plik konfiguracji aplikacji 
-                               zawierający ustawienia powiązania zestawu
- /moduleassemblyname:&lt;ciąg&gt;    Nazwa zestawu, którego częścią 
-                               ma być ten moduł
- /modulename:&lt;ciąg&gt;            Określ nazwę modułu źródłowego
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3637,7 +3664,7 @@ Jeśli taka klasa zostanie użyta jako klasa podstawowa i klasa pochodna definiu
     <value>Klasy CallerMemberNameAttribute nie można zastosować, ponieważ nie ma standardowych konwersji z typu „{0}” do typu „{1}”</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>Nie można zwrócić elementu członkowskiego parametru „{0}” przez odwołanie, ponieważ to nie jest parametr ref ani out</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(Lokalizacja symbolu związanego z poprzednim błędem)</value>
@@ -3682,7 +3709,7 @@ Jeśli taka klasa zostanie użyta jako klasa podstawowa i klasa pochodna definiu
     <value>Nie można zwrócić parametru „{0}” przez odwołanie, ponieważ to nie jest parametr ref ani out</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>Elementów definiowanych w przestrzeni nazw nie można jawnie deklarować jako prywatnych, chronionych lub chronionych wewnętrznych.</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>Opcję /moduleassemblyname można określić tylko w przypadku kompilowania elementu docelowego typu „module”.</value>
@@ -3851,6 +3878,9 @@ Jeśli taka klasa zostanie użyta jako klasa podstawowa i klasa pochodna definiu
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>Element „{0}” definiuje operator == lub !=, lecz nie przesłania metody Object.GetHashCode()</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>Jeden z parametrów operatora binarnego musi być typem zawierającym</value>
@@ -4315,7 +4345,7 @@ Jeśli taka klasa zostanie użyta jako klasa podstawowa i klasa pochodna definiu
     <value>Parametr typu „{1}” ma ograniczenie „struct”, dlatego elementu „{1}” nie można użyć jako ograniczenia dla „{0}”.</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>Wstępnie zdefiniowany typ „{0}” nie został zdefiniowany ani zaimportowany</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>Argument typu nie może mieć wartości null</value>
@@ -4480,7 +4510,7 @@ Jeśli taka klasa zostanie użyta jako klasa podstawowa i klasa pochodna definiu
     <value>Argument „{0}”: nie można przekonwertować z „{1}” na „{2}”</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>Specyfikacje argumentu nazwanego muszą występować po wszystkich stałych argumentach, które zostały określone</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>Ograniczenia parametrów typu „{0}” metody „{1}” muszą być zgodne z ograniczeniami parametrów typu „{2}” metody interfejsu „{3}”. Rozważ użycie jawnej implementacji interfejsu.</value>
@@ -5060,6 +5090,9 @@ Jeśli taka klasa zostanie użyta jako klasa podstawowa i klasa pochodna definiu
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>indeksator z wyrażeniem w treści</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>„{0}”: nie może pochodzić od typu dynamicznego</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.pt-BR.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.pt-BR.resx
@@ -380,6 +380,9 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>Somente membros em conformidade com CLS podem ser abstratos</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>Assembly e módulo "{0}" não podem diferentes processadores como destino.</value>
   </data>
@@ -468,7 +471,7 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
     <value>"{0}" não implementa o padrão "{1}". "{2}" é ambíguo com "{3}".</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>Opção '{0}' inválida para /langversion; deve ser ISO-1, ISO-2, Padrão, Mais Recente ou uma versão válida no intervalo de 1 a 7.1.</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>Um nome qualificado para alias não é uma expressão.</value>
@@ -713,6 +716,9 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>Constante de ponto flutuante está fora do intervalo do tipo "{0}"</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>Não é possível emitir informações de depuração para um texto de origem sem codificação.</value>
   </data>
@@ -733,6 +739,9 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>Espera-se uma marca de fim para o elemento "{0}".</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>Os argumentos de tipo não são permitidos no nome do operador.</value>
@@ -872,11 +881,14 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>O tipo "{0}" do assembly '{1}' não pode ser usado em limites de assembly porque ele tem um argumento de tipo genérico que é um tipo de interoperabilidade inserido.</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>O operador as deve ser usado com um tipo de referência ou tipo anulável ("{0}" é um tipo de valor não-anulável)</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>O método abstract "{0}" não pode ser marcado como virtual</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>"{0}": classes static não podem conter operadores definidos pelo usuário</value>
@@ -1028,6 +1040,9 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>Expressão de filtro é uma constante, considere remover o filtro</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>O recurso '{0}' não está disponível em C# 7.1. Use a versão de linguagem {1} ou superior.</value>
   </data>
@@ -1109,6 +1124,9 @@ Você pode suprimir o aviso se tiver certeza de que não vai querer aguardar a c
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>O membro "{0}" não oculta um membro acessível. A palavra-chave new não é necessária.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>Um número que foi passado para a diretiva de pré-processador de aviso #pragma não era um número de aviso válido. Verifique se o número representa um aviso, não um erro.</value>
   </data>
@@ -1126,6 +1144,9 @@ Você pode suprimir o aviso se tiver certeza de que não vai querer aguardar a c
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>#r somente é permitido em scripts</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>Árvore de sintaxe já está presente</value>
@@ -1322,6 +1343,9 @@ Você pode suprimir o aviso se tiver certeza de que não vai querer aguardar a c
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>Opção de alias de referência inválida: "{0}=" -- nome de arquivo ausente</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>Membros do campo somente leitura '{0}' não podem ser retornados por referência</value>
   </data>
@@ -1347,7 +1371,7 @@ Você pode suprimir o aviso se tiver certeza de que não vai querer aguardar a c
     <value>Um evento de Tempo de Execução do Windows não pode ser passado como parâmetro out ou ref.</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>Instância do tipo "{0}" não pode ser usado dentro de uma função anônima, expressão de consulta, bloco de iteradores ou método assíncrono</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>"{0}" não implementa membro de interface "{1}". "{2}" não pode implementar "{1}" porqu não tem o tipo de retorno correspondente de "{3}".</value>
@@ -1828,7 +1852,7 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
     <value>O operando de aumento ou diminuição deve ser uma variável, propriedade ou indexador</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Só há suporte para o comutador /embed ao emitir um PDB Portátil (/debug:portable ou /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>"{0}" não pode ser extern e abstract</value>
@@ -3111,8 +3135,8 @@ Se tal classe for usada como uma classe base e se a classe derivada definir um d
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>Ambiguidade entre "{0}" e "{1}"</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>Somente métodos, classes, estruturas ou interfaces podem ser parciais</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>Erro de sintaxe de linha de comando: falta Guid para a opção "{1}"</value>
@@ -3191,143 +3215,146 @@ Se tal classe for usada como uma classe base e se a classe derivada definir um d
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Opções do Compilador do Visual C#
+                              Visual C# Compiler Options
 
-                        – ARQUIVOS DE SAÍDA –
- /out:&lt;file&gt;                   Especifica o nome do arquivo de saída (padrão: nome de base do
-                               arquivo com a classe principal ou o primeiro arquivo)
- /target:exe                   Compila um executável de console (padrão) (Forma
-                               abreviada: /t:exe)
- /target:winexe                Compila um executável do Windows (Forma abreviada:
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               Compila uma biblioteca (Forma abreviada: /t:library)
- /target:module                Compila um módulo que pode ser adicionado a outro
-                               assembly (Forma abreviada: /t:module)
- /target:appcontainerexe (Forma abreviada: /t:module)
- /target:appcontainerexe       Compila um executável de contêiner de aplicativo (Forma abreviada: 
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              Compila um arquivo intermediário do Windows Runtime que 
-                               é consumido pelo WinMDExp (Forma abreviada: /t:winmdobj)
- /doc:&lt;file&gt;                   Arquivo de Documentação XML a ser gerado
- /refout:&lt;file&gt;                Saída do assembly de referência a ser gerado
- /platform:&lt;string&gt;            Limita em quais plataformas o código pode ser executado: x86,
-                               Itanium, x64, arm, anycpu32bitpreferred ou 
-                               anycpu. O padrão é anycpu.
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        – ARQUIVOS DE ENTRADA –
- /recurse:&lt;wildcard&gt;           Inclui todos os arquivos no diretório e 
-                               subdiretórios atuais de acordo com as especificações de 
-                               curinga
- /reference:&lt;alias&gt;=&lt;file&gt;     Metadados de referência do arquivo de assembly 
-                               especificado usando o alias informado (Forma abreviada: /r)
- /reference:&lt;file list&gt;        Metadados de referência dos arquivos de assembly 
-                               especificados (Forma abreviada: /r)
- /addmodule:&lt;file list&gt;        Vincula os módulos especificados ao assembly
- /link:&lt;file list&gt;             Insere metadados dos arquivos de assembly 
-                               de interoperalidade especificados (Forma abreviada: /l)
- /analyzer:&lt;file list&gt;         Executa os analisadores do assembly
-                               (Forma abreviada: /a)
- /additionalfile:&lt;file list&gt;   Arquivos adicionais que não afetam diretamente a geração
-                               de código, mas que podem ser usados por analisadores para produzir
-                               erros ou avisos.
- /embed                        Insere todos os arquivos de origem no PDB.
- /embed:&lt;file list&gt;            Insere arquivos específicos no PDB
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        – RECURSOS –
- /win32res:&lt;file&gt;              Especifica um arquivo de recurso Win32 (.res)
- /win32icon:&lt;file&gt;             Use esse ícone para a saída
- /win32manifest:&lt;file&gt;         Especifica um arquivo de manifesto Win32 (.xml)
- /nowin32manifest              Não inclui o manifesto Win32 padrão
- /resource:&lt;resinfo&gt;           Insere o recurso especificado (Forma abreviada: /res)
- /linkresource:&lt;resinfo&gt;       Vincula o recurso especificado ao assembly 
-                               (Forma abreviada: /linkres) Em que o formato resinfo 
-                               é &lt;file&gt;[,&lt;string name&gt;[,public|private]]
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        – GERAÇÃO DE CÓDIGO –
- /debug[+|-]                   Emite informações de depuração
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               Especifica o tipo de depuração ('full' é o padrão, 
-                               'portable' é um formato multiplataforma e
-                               'embedded' é um formato multiplataforma inserido no 
-                               .dll ou no .exe de destino)
- /optimize[+|-]                Habilita otimizações (Forma abreviada: /o)
- /deterministic                Produz um assembly determinístico
-                               (incluindo carimbo de data/hora e GUID da versão do módulo)
- /instrument:TestCoverage      Produz um assembly instrumentado para coletar
-                               informações de cobertura
- /sourcelink:&lt;file&gt;            Informações do link de origem a ser inserido no PDB.
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        – ERROS E AVISOS –
- /warnaserror[+|-]             Relata todos os avisos como erros
- /warnaserror[+|-]:&lt;warn list&gt; Relata avisos específicos como erros
- /warn:&lt;n&gt;                     Define o nível de aviso (0 – 4) (Forma abreviada: /w)
- /nowarn:&lt;warn list&gt;           Desabilita mensagens de aviso específicas
- /ruleset:&lt;file&gt;               Especifica um arquivo de conjunto de regras que desabilita um diagnóstico
-                               específico.
- /errorlog:&lt;file&gt;              Especifica um arquivo para registrar todos os diagnósticos do compilador e do
-                               analisador.
- /reportanalyzer               Relata informações adicionais do analisador, como o
-                               tempo de execução.
- 
-                        – LINGUAGEM –
- /checked[+|-]                 Gera verificações de estouro
- /unsafe[+|-]                  Permite código 'não seguro'
- /define:&lt;symbol list&gt;         Define símbolos de compilação condicional (Forma 
-                               abreviada: /d)
- /langversion:&lt;string&gt;         Especifica o modo da versão da linguagem: ISO-1, ISO-2, 3, 
-                               4, 5, 6, 7, 7.1, Padrão ou Mais Recente
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        – SEGURANÇA –
- /delaysign[+|-]               Faz a assinatura atrasada do assembly usando apenas a parte 
-                               pública da chave de nome forte
- /publicsign[+|-]              Faz a assinatura pública do assembly usando somente a parte
-                               pública da chave de nome forte
- /keyfile:&lt;file&gt;               Especifica um arquivo de chave de nome forte
- /keycontainer:&lt;string&gt;        Especifica um contêiner de chaves de nomes fortes
- /highentropyva[+|-]           Habilita ASLR de alta entropia
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        – DIVERSOS –
- @&lt;file&gt;                       Lê o arquivo de resposta para obter mais opções
- /help                         Exibe essa mensagem de uso (Forma abreviada: /?)
- /nologo                       Suprime a mensagem de direitos autorais do compilador
- /noconfig                     Não inclui o arquivo CSC.RSP automaticamente
- /parallel[+|-]                Build simultâneo.
- /version                      Exibe o número de versão do compilador e sai.
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        – AVANÇADO –
- /baseaddress:&lt;address&gt;        Endereço básico da biblioteca a ser compilada
- /checksumalgorithm:&lt;alg&gt;      Especifica o algoritmo para calcular a soma de verificação do 
-                               arquivo de origem armazenada no PDB. Os valores com suporte são:
-                               SHA1 (padrão) ou SHA256.
- /codepage:&lt;n&gt;                 Especifica a página de código a ser usada ao abrir os arquivos de 
-                               origem
- /utf8output                   Mensagens de saída do compilador em codificação UTF-8
- /main:&lt;type&gt;                  Especifica o tipo que contém o ponto de entrada 
-                               (ignora todos os outros pontos de entrada possíveis) (Forma 
-                               abreviada: /m)
- /fullpaths                    O compilador gera caminhos totalmente qualificados
- /filealign:&lt;n&gt;                Especifica o alinhamento usado para as seções do arquivo de 
-                               saída
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
+
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
  /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                               Especifica um mapeamento para os nomes dos caminhos de origem produzidos pelo
-                               compilador.
- /pdb:&lt;file&gt;                   Especifica o nome do arquivo de informações de depuração (padrão: 
-                               nome do arquivo de saída com a extensão .pdb)
- /errorendlocation             Linha e coluna de saída da localização final de 
-                               cada erro
- /preferreduilang              Especifica o nome da linguagem de saída preferencial.
- /nostdlib[+|-]                Não referencia a biblioteca padrão (mscorlib.dll)
- /subsystemversion:&lt;string&gt;    Especifica a versão do subsistema do assembly
- /lib:&lt;file list&gt;              Especifica diretórios adicionais a serem pesquisados em relação a 
-                               referências
- /errorreport:&lt;string&gt;         Especifica como lidar com os erros internos do compilador: 
-                               avisar, enviar, colocar na fila ou nada. O padrão é 
-                               colocar na fila.
- /appconfig:&lt;file&gt;             Especifica um arquivo de configuração de aplicativo 
-                               contendo configurações de associações do assembly
- /moduleassemblyname:&lt;string&gt;  Nome do assembly do qual o módulo fará 
-                               parte
- /modulename:&lt;string&gt;          Especifica o nome do módulo de origem
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
+                               queue.
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3637,7 +3664,7 @@ Se tal classe for usada como uma classe base e se a classe derivada definir um d
     <value>CallerMemberNameAttribute não pode ser aplicado porque não há conversões padrões do tipo "{0}" para o tipo "{1}"</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>Não é possível retornar um membro do parâmetro '{0}' por referência, pois ele não é um parâmetro ref ou out</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(Local do símbolo relacionado ao erro anterior)</value>
@@ -3682,7 +3709,7 @@ Se tal classe for usada como uma classe base e se a classe derivada definir um d
     <value>Não é possível retornar um parâmetro por referência '{0}', pois ele não é um parâmetro ref ou out</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>Os elementos definidos em um namespace não podem ser declarados explicitamente como privado, protegido ou interno protegido</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>A opção /moduleassemblyname só pode ser especificada ao criar um tipo de destino de 'module'</value>
@@ -3851,6 +3878,9 @@ Se tal classe for usada como uma classe base e se a classe derivada definir um d
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>"{0}" define o operador = = ou operador !=, mas não substitui Object.GetHashCode()</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>Um dos parâmetros de um operador binário deve ser do tipo recipiente</value>
@@ -4315,7 +4345,7 @@ Se tal classe for usada como uma classe base e se a classe derivada definir um d
     <value>O parâmetro de tipo "{1}" tem a restrição "struct" e, por isso, "{1}" não pode ser usado como uma restrição de "{0}"</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>O tipo pré-definido "{0}" não foi definido ou importado</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>Argumento de tipo não pode ser nulo</value>
@@ -4480,7 +4510,7 @@ Se tal classe for usada como uma classe base e se a classe derivada definir um d
     <value>Argumento {0}: não é possível converter de "{1}" para "{2}"</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>As especificações de argumento nomeado devem aparecer depois que todos os argumentos fixos forem especificados</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>As restrições para parâmetro de tipo "{0}" do método "{1}" deve coincidir com as restrições para o parâmetro de tipo "{2}" do método de interface "{3}". Ao invés disso, considere usar uma implementação de interface explícita.</value>
@@ -5060,6 +5090,9 @@ Se tal classe for usada como uma classe base e se a classe derivada definir um d
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>indexador apto para expressão</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>"{0}": não é possível derivar do tipo dinâmico</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.ru.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.ru.resx
@@ -380,6 +380,9 @@
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>Только члены, совместимые с CLS, могут быть абстрактными</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>Сборка и модуль "{0}" не могут предназначаться для разных процессоров.</value>
   </data>
@@ -468,7 +471,7 @@
     <value>"{0}" не реализует шаблон "{1}". "{2}" неоднозначен с "{3}".</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>Недопустимый параметр "{0}" для /langversion; должен быть ISO-1, ISO-2, Default, Latest или допустимой версией в диапазоне от 1 до 7.1.</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>Полное имя псевдонима не является выражением.</value>
@@ -713,6 +716,9 @@
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>Константа с плавающей запятой вне допустимого диапазона для типа "{0}".</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>Не удается выдать отладочную информацию для исходного текста без кодировки.</value>
   </data>
@@ -733,6 +739,9 @@
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>Требуется конечный тег для элемента "{0}".</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>Аргументы типа недопустимы в операторе nameof.</value>
@@ -872,11 +881,14 @@
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>Тип "{0}" из сборки "{1}" не может быть использован за границами сборки, так как имеет аргумент универсального типа, являющийся внедренным типом взаимодействия.</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>Оператор as должен использоваться со ссылочным типом или с типом, допускающим значение Null (тип "{0}" не допускает значение Null).</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>Абстрактный метод "{0}" не может быть помечен как virtual.</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>"{0}": статические классы не могут содержать определяемых пользователем операторов.</value>
@@ -1028,6 +1040,9 @@
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>Выражение фильтра является константой, попробуйте удалить фильтр.</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>Возможность "{0}" недоступна в C# 7.1. Используйте версию языка {1} или выше.</value>
   </data>
@@ -1109,6 +1124,9 @@
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>Член "{0}" не скрывает доступный член. Ключевое слово new не требуется.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>Номер, переданный в директиву препроцессора предупреждений #pragma, не являлся допустимым номером предупреждения. Убедитесь, что номер соответствует предупреждению, а не ошибке.</value>
   </data>
@@ -1126,6 +1144,9 @@
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>Использование #r допускается только в скриптах.</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>Синтаксическое дерево уже имеется</value>
@@ -1322,6 +1343,9 @@
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>Недопустимый параметр псевдонима ссылки: "{0}=" — не указано имя файла</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>Члены поля "{0}", доступного только для чтения, нельзя вернуть по ссылке</value>
   </data>
@@ -1347,7 +1371,7 @@
     <value>Событие среды выполнения Windows не может передаваться как параметр out или ref.</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>Экземпляр типа "{0}" нельзя использовать внутри анонимной функции, выражения запроса, блока итератора или асинхронного метода.</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>'{0}" не реализует член интерфейса "{1}". '{2}" не может реализовать "{1}", потому что не имеет соответствующего возвращаемого типа "{3}".</value>
@@ -1828,7 +1852,7 @@
     <value>Операндом оператора инкремента или декремента должна быть переменная, свойство или индексатор.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Параметр /embed поддерживается только при создании файлов Portable PDB (/debug:portable или /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>"{0}" не может одновременно внешним и абстрактным.</value>
@@ -3111,8 +3135,8 @@
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>Неоднозначность между "{0}" и "{1}"</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>Разделяемыми могут быть только методы, классы, структуры и интерфейсы.</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>Ошибка в синтаксисе командной строки: Отсутствует Guid для параметра "{1}".</value>
@@ -3191,143 +3215,146 @@
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Параметры компилятора Visual C#
+                              Visual C# Compiler Options
 
-                        - Выходные файлы -
- /out:&lt;файл&gt;                   Указывает имя выходного файла (по умолчанию: базовое имя
-                               файла с классом main или имя первого файла)
- /target:exe                   По умолчанию выполняет сборку консольного исполняемого файла (краткая
-                               форма: /t:exe)
- /target:winexe                Выполняет сборку исполняемого файла Windows (краткая форма:
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               Выполняет сборку библиотеки (краткая форма: /t:library)
- /target:module                Выполняет сборку модуля, который может быть добавлен в другую
-                               сборку (краткая форма: /t:module)
- /target:appcontainerexe       Выполняет сборку исполняемого файла контейнера приложений (краткая форма:
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              Выполняет сборку промежуточного файла среды выполнения Windows,
-                               используемого в WinMDExp (краткая форма: /t:winmdobj)
- /doc:&lt;файл&gt;                   Создаваемый XML-файл документации
- /refout:&lt;файл&gt;                Создаваемые выходные данные базовой сборки.
- /platform:&lt;строка&gt;            Ограничить платформы, на которых может выполняться этот код: x86,
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
                                Itanium, x64, arm, anycpu32bitpreferred, or
-                               anycpu. Значение по умолчанию — anycpu.
+                               anycpu. The default is anycpu.
 
-                        - Входные файлы -
- /recurse:&lt;подстановочный знак&gt;           Включить все файлы в текущем каталоге и
-                               подкаталогах в соответствии с заданным
-                               подстановочным знаком
- /reference:&lt;псевдоним&gt;=&lt;файл&gt;     Сослаться на метаданные из заданного файла
-                               сборки с помощью определенного псевдонима (краткая форма: /r)
- /reference:&lt;файлы&gt;        Сослаться на метаданные из заданных файлов
-                               сборки (краткая форма: /r)
- /addmodule:&lt;файлы&gt;        Скомпоновать указанные модули вместе с этой сборкой
- /link:&lt;файлы&gt;             Внедрить метаданные из указанных файлов
-                               сборок взаимодействия (краткая форма: /l)
- /analyzer:&lt;файлы&gt;         Запускать анализаторы из этой сборки
-                               (краткая форма: /a)
- /additionalfile:&lt;файлы&gt;   Дополнительные файлы, которые не оказывают прямого влияния на создание
-                               кода, но могут использоваться анализаторами для вывода
-                               ошибок или предупреждений.
- /embed                        Внедрить все исходные файлы в PDB.
- /embed:&lt;файлы&gt;            Внедрить указанные файлы в PDB.
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        - Ресурсы -
- /win32res:&lt;файл&gt;              Задает файл ресурсов Win32 (RES-файл)
- /win32icon:&lt;файл&gt;             Использовать этот значок для вывода.
- /win32manifest:&lt;файл&gt;         Задает файл манифеста Win32 (XML-файл).
- /nowin32manifest              Не включать манифест Win32 по умолчанию.
- /resource:&lt;ресурс&gt;           Внедрить указанный ресурс (краткая форма: /res)
- /linkresource:&lt;ресурс&gt;       Скомпоновать указанный ресурс вместе с этой сборкой
-                               (краткая форма: /linkres), где данные о ресурсах имеют формат
-                               &lt;файл&gt;[,&lt;имя строки&gt;[,public|private]]
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        - Создание кода -
- /debug[+|-]                   Выдать отладочную информацию.
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               Задать тип отладки (по умолчанию — full,
-                               portable — кроссплатформенный формат,
-                               embedded — кроссплатформенный формат, внедряемый в
-                               целевой DLL- или EXE-файл)
- /optimize[+|-]                Включить оптимизацию (краткая форма: /o)
- /deterministic                Создать детерминированную сборку
-                               (включая GUID версии модуля и метку времени)
- /refonly                      Создать базовую сборку вместо основных выходных данных.
- /instrument:TestCoverage      Создать сборку, инструментированную для сбора
-                               сведений об объеме протестированного кода.  
- /sourcelink:&lt;file&gt;            Данные о ссылке на исходные файлы для внедрения в PDB.
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        - Ошибки и предупреждения -
- /warnaserror[+|-]             Записывать все предупреждения как ошибки.
- /warnaserror[+|-]:&lt;предупреждения&gt; Записывать указанные предупреждения как ошибки.
- /warn:&lt;n&gt;                     Задать уровень генерации предупреждений (0–4) (краткая форма: /w)
- /nowarn:&lt;предупреждения&gt;           Отключить указанные предупреждения.
- /ruleset:&lt;файл&gt;               Указать файл набора правил, отключающий определенные
-                               диагностические операции.
- /errorlog:&lt;файл&gt;              Указать файл для записи всех диагностических данных
-                               компилятора и анализатора.
- /reportanalyzer               Сообщить дополнительные сведения об анализаторе, например
-                               время выполнения.
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        - Язык -
- /checked[+|-]                 Создать проверки переполнений.
- /unsafe[+|-]                  Допускать "небезопасный" код.
- /define:&lt;список символов&gt;         Определить символы условной компиляции (краткая
-                               форма: /d)
- /langversion:&lt;строка&gt;         Указать режим языковой версии: ISO-1, ISO-2, 3,
-                               4, 5, 6, 7, 7.1, Default или Latest
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        - Безопасность -
- /delaysign[+|-]               Использовать отложенную подпись для сборки, применяя только открытую
-                               часть ключа строгого имени
- /publicsign[+|-]              Подписать сборку, используя только открытую
-                               часть ключа строгого имени
- /keyfile:&lt;файл&gt;               Указать файл ключей строгого имени.
- /keycontainer:&lt;строка&gt;        Указать контейнер ключей строгого имени.
- /highentropyva[+|-]           Включить ASLR с высокой энтропией.
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        - Прочее -
- @&lt;файл&gt;                       Считать файл ответов с дополнительными параметрами.
- /help                         Отображать это сообщение об использовании (краткая форма: /?)
- /nologo                       Запрещать отображение сообщения компилятора об авторских правах.
- /noconfig                     Не включать файл CSC.RSP автоматически.
- /parallel[+|-]                Параллельная сборка.
- /version                      Отобразить номер версии компилятора и выйти.
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
 
-                        - Дополнительно -
- /baseaddress:&lt;адрес&gt;        Базовый адрес библиотеки, для которой выполняется сборка.
- /checksumalgorithm:&lt;алгоритм&gt;      Задать алгоритм для расчета контрольной суммы
-                               исходного файла, хранимой в формате PDB. Поддерживаемые значения:
-                               SHA1 (по умолчанию) или SHA256.
- /codepage:&lt;n&gt;                 Задать кодовую страницу, используемую при открытии исходных
-                               файлов.
- /utf8output                   Выводить сообщения компилятора в кодировке UTF-8.
- /main:&lt;тип&gt;                  Указать тип, содержащий точку входа
-                               (все другие возможные точки входа игнорируютя) (краткая
-                               форма: /m)
- /fullpaths                    Компилятор создает полные пути.
- /filealign:&lt;n&gt;                Задать выравнивание для разделов выходных
-                               файлов.
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
  /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                               Задать сопоставление для выходных данных имен исходного пути по
-                               компилятору.
- /pdb:&lt;файл&gt;                   Задать имя файла для отладочной информации (по умолчанию
-                               используется имя выходного файла с расширением PDB)
- /errorendlocation             Выводить строку и столбец конечного расположения
-                               каждой ошибки.
- /preferreduilang              Указать имя предпочтительного языка вывода.
- /nostdlib[+|-]                Не обращаться к стандартной библиотеке (mscorlib.dll).
- /subsystemversion:&lt;строка&gt;    Задать версию подсистемы этой сборки.
- /lib:&lt;файлы&gt;              Задать дополнительные каталоги для поиска
-                               ссылок.
- /errorreport:&lt;строка&gt;         Указать способ обработки внутренних ошибок компилятора:
-                               prompt, send, queue или none. По умолчанию используется
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
                                queue.
- /appconfig:&lt;файл&gt;             Указать файл конфигурации приложения,
-                               содержащий параметры привязки сборки.
- /moduleassemblyname:&lt;строка&gt;  Имя сборки, частью которой будет являться
-                               этот модуль.
- /modulename:&lt;строка&gt;          Задать имя исходного модуля.
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3637,7 +3664,7 @@
     <value>Невозможно применить CallerMemberNameAttribute, так как отсутствуют стандартные преобразования из типа "{0}" в тип "{1}".</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>Невозможно вернуть член параметра "{0}" по ссылке, так как это не параметр ref или out</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(Местоположение символа, связанного с предыдущей ошибкой)</value>
@@ -3682,7 +3709,7 @@
     <value>Невозможно вернуть параметр "{0}" по ссылке, так как это не параметр ref или out</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>Элементы, определенные в пространстве имен, не могут объявляться в явном виде как частные, защищенные или защищенные внутренние.</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>Параметр /moduleassemblyname может использоваться только при сборке модуля.</value>
@@ -3851,6 +3878,9 @@
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>"{0}" определяет оператор "==" или оператор "!=", но не переопределяет Object.GetHashCode().</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>Тип одного из параметров бинарного оператора должен быть вмещающим.</value>
@@ -4315,7 +4345,7 @@
     <value>Параметр типа "{1}" имеет ограничение "struct", поэтому "{1}" не может использоваться в качестве ограничения для "{0}".</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>Предопределенный тип "{0}" не определен и не импортирован</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>Аргумент типа не может иметь значение Null</value>
@@ -4480,7 +4510,7 @@
     <value>Аргумент {0}: не удается преобразовать из "{1}" в "{2}".</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>Спецификации именованного аргумента должны появляться во всех указанных фиксированных аргументах.</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>Ограничения для параметра типа "{0}" метода "{1}" должны соответствовать ограничениям параметра типа "{2}" метода интерфейса "{3}". Рассмотрите возможность явной реализации интерфейса.</value>
@@ -5060,6 +5090,9 @@
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>индексатор, воплощающий выражение</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>'{0}": не может наследовать от динамического типа.</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.tr.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.tr.resx
@@ -380,6 +380,9 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>Yalnızca CLS uyumlu üyeler soyut olabilir</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>Derleme ve '{0}' modülü farklı işlemcileri hedefleyemez.</value>
   </data>
@@ -468,7 +471,7 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
     <value>'{0}', '{1}' kalıbını uygulamaz. '{2}', '{3}' ile belirsiz.</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>/langversion için '{0}' seçeneği geçersiz; ISO-1, ISO-2, Default, Latest ya da 1 ile 7.1 aralığında geçerli bir sürüm olmalıdır.</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>Diğer adla nitelenmiş ad, bir ifade değil.</value>
@@ -713,6 +716,9 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>Kayan noktalı sabit '{0}' türünün aralığı dışında</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>Kodlama olmadan bir kaynak metin için hata ayıklama bilgileri yayılamıyor.</value>
   </data>
@@ -733,6 +739,9 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>'{0}' öğesi için bir bitiş etiketi bekleniyor.</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>nameof işlecinde tür bağımsız değişkenlerine izin verilmez.</value>
@@ -872,11 +881,14 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>'{1}' bütünleştirilmiş kodundaki '{0}' türü, gömülü birlikte çalışma türü olan bir genel tür bağımsız değişkeni içerdiğinden bütünleştirilmiş kod sınırları arasında kullanılamaz.</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>As işleci bir başvuru türüyle veya null olabilen bir türle birlikte kullanılmalıdır ('{0}', null olamayan bir değer türüdür)</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>'{0}' soyut yöntemi sanal olarak işaretlenemiyor</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>'{0}': statik sınıflar kullanıcı tanımlı işleçler içeremez</value>
@@ -1028,6 +1040,9 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>Filtre ifadesi bir sabittir, filtreyi kaldırmayı deneyin</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>'{0}' özelliği C# 7.1'de kullanılamıyor. Lütfen {1} veya daha yüksek dil sürümünü kullanın.</value>
   </data>
@@ -1109,6 +1124,9 @@ Yalnızca asenkron çağrının tamamlanmasını beklemek istemediğinizden ve �
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>'{0}' üyesi, erişilebilir bir üyeyi gizlemez. Yeni anahtar sözcük gerekli değil.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>#pragma uyarı önişlemcisi yönergesine geçirilen bir sayı geçerli bir uyarı sayısı değildi. Sayının bir hatayı değil, bir uyarıyı temsil ettiğini doğrulayın.</value>
   </data>
@@ -1126,6 +1144,9 @@ Yalnızca asenkron çağrının tamamlanmasını beklemek istemediğinizden ve �
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>#r öğesine yalnızca komut dosyalarında izin verilir</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>Sözdizimi ağacı zaten var</value>
@@ -1322,6 +1343,9 @@ Yalnızca asenkron çağrının tamamlanmasını beklemek istemediğinizden ve �
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>Geçersiz başvuru diğer adı seçeneği: '{0}=' -- dosya adı eksik</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>Salt okunur '{0}' alanının üyeleri başvuru ile döndürülemez</value>
   </data>
@@ -1347,7 +1371,7 @@ Yalnızca asenkron çağrının tamamlanmasını beklemek istemediğinizden ve �
     <value>Bir Windows Çalışma Zamanı olayı out veya ref parametresi olarak geçirilemeyebilir.</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>'{0}' türünün örneği anonim bir işlevde, sorgu ifadesinde, yineleyici bloğunda veya zaman uyumsuz bir yöntemde kullanılamaz</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>'{0}, '{1}' arabirim üyesini uygulamıyor. '{3}' eşleşen dönüş türüne sahip olmadığından '{2}' '{1}' öğesini uygulayamaz.</value>
@@ -1828,7 +1852,7 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
     <value>Artırma veya azaltma işlecinin işleyicisi bir değişken, özellik veya dizin erişimcisi olmalıdır</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>/embed anahtarı yalnızca Taşınabilir PDB gösterilirken desteklenir (/debug:portable veya /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>'{0}' hem dış hem soyut olamaz</value>
@@ -3111,8 +3135,8 @@ Bu sınıf temel sınıf olarak kullanılırsa ve türetilen sınıf bir yıkıc
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>'{0}' ve '{1}' arasında belirsizlik var</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>Yalnızca yöntemler, sınıflar, yapılar ve arabirimler kısmi olabilir</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>Komut satırı sözdizimi hatası: '{1}' seçeneği için Guid eksik</value>
@@ -3191,141 +3215,146 @@ Bu sınıf temel sınıf olarak kullanılırsa ve türetilen sınıf bir yıkıc
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Visual C# Derleyici Seçenekleri
+                              Visual C# Compiler Options
 
-                        - ÇIKIŞ DOSYALARI -
- /out:&lt;dosya&gt;                   Çıkış dosyası adını belirt (varsayılan: main
-                               sınıfının olduğu dosyanın veya ilk dosyanın temel adı)
- /target:exe                   Konsol yürütülebilir dosyası derle (varsayılan) (Kısa 
-                               biçim: /t:exe)
- /target:winexe                Windows yürütülebilir dosyası derle (Kısa biçim: 
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               Kitaplık derle (Kısa biçim: /t:library)
- /target:module                Başka bir bütünleştirilmiş koda eklenebilecek bir 
-                               modül derle (Kısa biçim: /t:module)
- /target:appcontainerexe       Appcontainer yürütülebilir dosyası derle (Kısa biçim: 
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              WinMDExp tarafından kullanılan bir Windows Çalışma Zamanı 
-                               ara dosyası derle (Kısa biçim: /t:winmdobj)
- /doc:&lt;dosya&gt;                   Oluşturulacak XML Belge dosyası
- /platform:&lt;dize&gt;            Bu kodun çalıştırılabileceği platformları sınırla: x86,
-                               Itanium, x64, arm, anycpu32bitpreferred veya 
-                               anycpu. Varsayılan: anycpu.
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        - GİRİŞ DOSYALARI -
- /recurse:&lt;joker karakter&gt;           Joker karakter belirtimlerine göre, geçerli 
-                               dizindeki ve alt dizinlerdeki tüm dosyaları 
-                               dahil et
- /reference:&lt;diğer ad&gt;=&lt;dosya&gt;     Belirtilen bütünleştirilmiş kod dosyasındaki meta verilere 
-                               belirtilen diğer adla başvur (Kısa biçim: /r)
- /reference:&lt;dosya listesi&gt;        Belirtilen bütünleştirilmiş kod dosyalarındaki meta verilere 
-                               başvur (Kısa biçim: /r)
- /addmodule:&lt;dosya listesi&gt;        Belirtilen modülleri bu bütünleştirilmiş koda bağla 
- /link:&lt;dosya listesi&gt;             Belirtilen birlikte çalışma bütünleştirilmiş kod dosyalarından 
-                               meta veri ekle (Kısa biçim: /l)
- /analyzer:&lt;dosya listesi&gt;         Çözümleyicileri bu bütünleştirilmiş koddan çalıştır
-                               (Kısa biçim: /a)
- /additionalfile:&lt;dosya listesi&gt;   Kod oluşturmayı doğrudan etkilemeyen ancak hata
-                               ve uyarılar oluşturmak için çözümleyicilerin
-                               kullanılabileceği ek dosyalar.
- /embed                        Tüm kaynak dosyalarını PDB'ye ekle.
- /embed:&lt;dosya listesi&gt;            Belirli dosyaları PDB'ye ekle.
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        - KAYNAKLAR -
- /win32res:&lt;dosya&gt;              Bir Win32 kaynak dosyası (.res) belirt
- /win32icon:&lt;dosya&gt;             Çıkış için bu simgeyi kullan
- /win32manifest:&lt;dosya&gt;         Bir Win32 bildirim dosyası (.xml) belirt
- /nowin32manifest              Varsayılan Win32 bildirimini dahil etme
- /resource:&lt;kaynak bilgileri&gt;           Belirtilen kaynağı ekle (Kısa biçim: /res)
- /linkresource:&lt;kaynak bilgileri&gt;       Belirtilen kaynağı bu bütünleştirilmiş koda bağla 
-                               (Kısa biçim: /linkres) Burada kaynak bilgisi biçimi: 
-                               &lt;dosya&gt;[,&lt;dize adı&gt;[,public|private]]
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        - KOD OLUŞTURMA -
- /debug[+|-]                   Hata ayıklama bilgilerini yayınla
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               Hata ayıklama türünü belirt (varsayılan: 'full' 
-                               'portable': platformlar arası bir biçim,
-                               'embedded': hedef .dll veya .exe dosyasına 
-                               eklenmiş platformlar arası bir biçim)
- /optimize[+|-]                İyileştirmeleri etkinleştir (Kısa biçim: /o)
- /deterministic                Belirlenimci bir bütünleştirilmiş kod oluştur
-                               (modül sürümü GUID'si ve zaman damgası dahil)
- /instrument:TestCoverage      Kapsam bilgilerini toplamak üzere
-                               işaretlenen bir bütünleştirilmiş kod üret
- /sourcelink:&lt;dosya&gt;            PDB'ye eklenecek kaynak bağlantı bilgileri.
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        - HATALAR VE UYARILAR -
- /warnaserror[+|-]             Tüm uyarıları hata olarak bildir
- /warnaserror[+|-]:&lt;uyarı listesi&gt; Belirli uyarıları hata olarak bildir
- /warn:&lt;n&gt;                     Uyarı düzeyini belirle (0-4) (Kısa biçim: /w)
- /nowarn:&lt;uyarı listesi&gt;           Belirli uyarı iletilerini devre dışı bırak
- /ruleset:&lt;dosya&gt;               Belirli tanılamaları devre dışı bırakan bir
-                               kural kümesi dosyası belirt.
- /errorlog:&lt;dosya&gt;              Tüm derleyici ve çözümleyici tanılamalarını günlüğe kaydetmek için
-                               bir dosya belirt.
- /reportanalyzer               Yürütme zamanı gibi ek yürütme
-                               bilgilerini bildir.
- 
-                        - DİL -
- /checked[+|-]                 Taşma denetimleri oluştur
- /unsafe[+|-]                  'Güvensiz' koda izin ver
- /define:&lt;sembol listesi&gt;         Koşullu derleme sembolleri tanımla (Kısa 
-                               biçim: /d)
- /langversion:&lt;dize&gt;         Dil sürüm modunu belirt: ISO-1, ISO-2, 3, 
-                               4, 5, 6, 7, 7.1, Default veya Latest
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        - GÜVENLİK -
- /delaysign[+|-]               Bütünleştirilmiş kodu, tanımlayıcı ad anahtarının yalnızca genel 
-                               kısmını kullanarak gecikmeli imzala
- /publicsign[+|-]              Bütünleştirilmiş kodu, tanımlayıcı ad anahtarının yalnızca genel
-                               kısmını kullanarak genel olarak imzala
- /keyfile:&lt;dosya&gt;               Bir tanımlayıcı ad anahtarı dosyası belirt 
- /keycontainer:&lt;dize&gt;        Bir tanımlayıcı ad anahtarı kapsayıcısı belirt
- /highentropyva[+|-]           Yüksek entropili ASLR'yi etkinleştir
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        - ÇEŞİTLİ -
- @&lt;dosya&gt;                       Daha fazla seçenek için yanıt dosyasını oku
- /help                         Bu kullanım iletisini görüntüle (Kısa biçim: /?)
- /nologo                       Derleyici telif hakkı iletisini gösterme
- /noconfig                     CSC.RSP dosyasını otomatik olarak dahil etme
- /parallel[+|-]                Eşzamanlı derleme.
- /version                      Derleyici sürüm numarasını görüntüle ve çık.
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        - GELİŞMİŞ -
- /baseaddress:&lt;adres&gt;        Derlenecek kitaplığın taban adresi
- /checksumalgorithm:&lt;alg&gt;      PDB'de depolanan kaynak dosya sağlama toplamını 
-                               hesaplama algoritmasını belirt. Desteklenen değerler:
-                               SHA1 (varsayılan) veya SHA256.
- /codepage:&lt;n&gt;                 Kaynak dosyalarını açarken kullanılacak kod 
-                               sayfasını belirt
- /utf8output                   Derleyici iletilerini UTF-8 kodlamasında görüntüle 
- /main:&lt;tür&gt;                  Giriş noktasını içeren türü belirt 
-                               (diğer tüm olası giriş noktalarını yoksay) (Kısa 
-                               biçim: /m)
- /fullpaths                    Derleyici tam yollar oluşturur
- /filealign:&lt;n&gt;                Çıkış dosyasının bölümleri için kullanılan 
-                               hizalamayı belirt
- /pathmap:&lt;A1&gt;=&lt;D1&gt;,&lt;A2&gt;=&lt;D2&gt;,...
-                               Derleyici tarafından gösterilen kaynak yolu adları için bir eşleme
-                               belirt.
- /pdb:&lt;dosya&gt;                   Hata ayıklama bilgileri dosyasının adını belirt (varsayılan: 
-                               .pdb uzantılı çıkış dosyasının adı)
- /errorendlocation             Her hatanın bitiş konumunun satır ve sütununu 
-                               göster
- /preferreduilang              Tercih edilen çıkış dilini belirt.
- /nostdlib[+|-]                Standart kitaplığa (mscorlib.dll) başvurma
- /subsystemversion:&lt;dize&gt;    Bu bütünleştirilmiş kodun alt sistem sürümünü belirt
- /lib:&lt;dosya listesi&gt;              İçinde başvuruların aranacağı ek dizinleri 
-                               belirt
- /errorreport:&lt;dize&gt;         İç derleyici hatalarının nasıl işleneceğini belirt: 
-                               prompt, send, queue veya none. Varsayılan: 
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
+
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
+ /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
                                queue.
- /appconfig:&lt;dosya&gt;             Bütünleştirilmiş kod bağlama ayarlarını içeren 
-                               bir uygulama yapılandırma dosyası belirt
- /moduleassemblyname:&lt;dize&gt;  Bu modülün parçası olacağı bütünleştirilmiş kodun 
-                               adı
- /modulename:&lt;dize&gt;          Kaynak modülün adını belirt
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3635,7 +3664,7 @@ Bu sınıf temel sınıf olarak kullanılırsa ve türetilen sınıf bir yıkıc
     <value>'{0}' türünden '{1}' türüne standart dönüştürme olmadığından CallerMemberNameAttribute uygulanamıyor</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>'{0}' parametresi bir ref veya out parametresi olmadığından, üyesi başvuru ile döndürülemez</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(Önceki hatayla ilgili sembolün konumu)</value>
@@ -3680,7 +3709,7 @@ Bu sınıf temel sınıf olarak kullanılırsa ve türetilen sınıf bir yıkıc
     <value>'{0}' parametresi bir ref veya out parametresi olmadığından başvuru ile döndürülemez</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>Ad alanında tanımlanan öğeler açıkça private, protected veya protected internal olarak bildirilemez</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>/moduleassemblyname seçeneği yalnızca 'module' öğesinin hedef türü oluşturulurken belirtilebilir</value>
@@ -3849,6 +3878,9 @@ Bu sınıf temel sınıf olarak kullanılırsa ve türetilen sınıf bir yıkıc
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>'{0}' işleç == veya işleç != öğesini tanımlar ancak Object.GetHashCode() öğesini geçersiz kılmaz</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>İkili işlecin parametrelerinden biri kapsayan tür olmalıdır</value>
@@ -4313,7 +4345,7 @@ Bu sınıf temel sınıf olarak kullanılırsa ve türetilen sınıf bir yıkıc
     <value>'{1}' tür parametresinde 'struct' kısıtlaması olduğundan '{1}' '{0}' için kısıtlama olarak kullanılamaz</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>Önceden tanımlanmış '{0}' türü, tanımlanmamış veya içeri aktarılmamış</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>Tür bağımsız değişkeni null olamaz</value>
@@ -4478,7 +4510,7 @@ Bu sınıf temel sınıf olarak kullanılırsa ve türetilen sınıf bir yıkıc
     <value>{0} bağımsız değişkeni: '{1}' öğesinden '{2}' öğesine dönüştürülemiyor</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>Adlandırılmış bağımsız değişken belirtimleri düzeltilmiş tüm sabit değişkenler belirtildikten sonra görünmelidir</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>'{1}' yönteminin '{0}' tür parametreleri için kısıtlamalar '{3}' arabirim yönteminin '{2}' tür parametresi için kısıtlamalarla eşleşmelidir. Yerine açık arabirim uygulaması kullanmayı düşünün.</value>
@@ -5058,6 +5090,9 @@ Bu sınıf temel sınıf olarak kullanılırsa ve türetilen sınıf bir yıkıc
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>ifade gövdeli dizin oluşturucu</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>'{0}': dinamik türden türetilemez</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.zh-Hans.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.zh-Hans.resx
@@ -380,6 +380,9 @@
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>只有符合 CLS 的成员才能是抽象的</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>程序集和模块“{0}”不能以不同处理器为目标。</value>
   </data>
@@ -468,7 +471,7 @@
     <value>“{0}”不实现“{1}”模式。“{2}”与“{3}”一起使用时目的不明确。</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>选项“{0}”对于 /langversion 无效；必须是 ISO-1、ISO-2、默认版本、最新版本或 1 到 7.1 范围内的有效版本。</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>别名限定名称不是表达式。</value>
@@ -713,6 +716,9 @@
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>浮点常量超出“{0}”类型的范围</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>无法在不进行编码的情况下发出源文本的调试信息。</value>
   </data>
@@ -733,6 +739,9 @@
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>元素“{0}”需要结束标记。</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>Nameof 运算符中不允许使用类型参数。</value>
@@ -872,11 +881,14 @@
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>无法跨程序集边界使用程序集“{1}”中的类型“{0}”，因为它有身为嵌入的互操作类型的泛型类型参数。</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>as 运算符必须与引用类型或可以为 null 的类型一起使用(“{0}”是不可以为 null 值的类型)</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>抽象方法“{0}”不能标记为 virtual</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>“{0}”: 静态类不能包含用户定义的运算符</value>
@@ -1028,6 +1040,9 @@
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>筛选器表达式是常量，请考虑删除筛选器</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>功能“{0}”在 C# 7.1 中不可用。请使用 {1} 或更高的语言版本。</value>
   </data>
@@ -1109,6 +1124,9 @@
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>成员“{0}”不会隐藏可访问成员。不需要关键字 new。</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>传递到 #pragma 警告预处理器指令的编号不是有效的警告编号。验证该编号是否表示警告而不是错误。</value>
   </data>
@@ -1126,6 +1144,9 @@
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>仅脚本中允许使用 #r</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>语法树已存在</value>
@@ -1322,6 +1343,9 @@
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>无效的引用别名选项:“{0}=”-- 缺少文件名</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>只读字段“{0}”的成员无法按引用返回</value>
   </data>
@@ -1347,7 +1371,7 @@
     <value>无法作为 out 或 ref 参数传递 Windows 运行时事件。</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>“{0}”类型的实例不能在匿名函数、查询表达式、迭代器块或异步方法中使用</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>“{0}”不实现接口成员“{1}”。“{2}”无法实现“{1}”，因为它没有“{3}”的匹配返回类型。</value>
@@ -1828,7 +1852,7 @@
     <value>递增或递减运算符的操作数必须是变量、属性或索引器</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>/仅在发出可移植 PDB 时支持嵌入式开关(/debug:portable 或 /debug:embedded)。</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>“{0}”不能既是外部的又是抽象的</value>
@@ -3111,8 +3135,8 @@
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>在“{0}”和“{1}”之间具有二义性</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>只有方法、类、结构或接口才能为分部形式</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>命令行语法错误: 选项“{1}”缺少 Guid</value>
@@ -3191,143 +3215,146 @@
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Visual C# 编译器选项
+                              Visual C# Compiler Options
 
-                        - 输出文件 -
- /out:&lt;file&gt;                   指定输出文件名称(默认: 具有主类的文件或
-                               第一个文件的基名称)
- /target:exe                   生成控制台可执行文件(默认)(缩
-                               写: /t:exe)
- /target:winexe                生成 Windows 可执行文件(缩写: 
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               生成库(缩写: /t:library)
- /target:module                生成可添加到另一个程序集的
-                               模块(缩写: /t:module)
- /target:appcontainerexe       生成 Appcontainer 可执行文件(缩写: 
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              生成 WinMDExp 使用的
-                               Windows 运行时中间文件(缩写: /t:winmdobj)
- /doc:&lt;file&gt;                   要生成的 XML 文档文件
- /refout:&lt;file&gt;                要生成的引用程序集输出
- /platform:&lt;string&gt;            限制此代码可以在其上运行的平台: x86、
-                               Itanium、x64、arm、anycpu32bitpreferred 或
-                               anycpu。默认平台为 anycpu。
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        - 输入文件 -
- /recurse:&lt;wildcard&gt;           根据通配符规范包括当前目录和
-                               子目录中的所有
-                               文件
- /reference:&lt;alias &gt;=&lt;file&gt;     使用给定别名从指定程序集
-                               引用元数据(缩写: /r)
- /reference:&lt;file list&gt;        从指定程序集文件引用
-                               元数据(缩写: /r)
- /addmodule:&lt;file list&gt;        将指定模块链接到此程序集中
- /link:&lt;file list&gt;             嵌入指定互操作程序集文件中的
-                               元数据(缩写: /l)
- /analyzer:&lt;file list&gt;         运行此程序集中的分析器
-                               (缩写: /a)
- /additionalfile:&lt;file list&gt;   不会直接影响代码生成
-                               但可能被分析器用于生成
-                               错误或警告的其他文件。
- /embed                        嵌入 PDB 中的所有源文件。
- /embed:&lt;file list&gt;            嵌入 PDB 中的特定文件
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        - 资源 -
- /win32res:&lt;file&gt;              指定 Win32 资源文件(.res)
- /win32icon:&lt;file&gt;             使用此图标输出
- /win32manifest:&lt;file&gt;         指定 Win32 清单文件(.xml)
- /nowin32manifest              不包括默认的 Win32 清单
- /resource:&lt;resinfo&gt;           嵌入指定资源(缩写: /res)
- /linkresource:&lt;resinfo&gt;       将指定资源链接到此程序集
-                               (缩写: /linkres)其中 resinfo 的格式
-                               是 &lt;文件&gt;[,&lt;字符串名称&gt;[,public|private]]
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        - 代码生成 -
- /debug[+|-]                   发出调试信息
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               指定调试类型(默认为 "full"，
-                               "portable" 为跨平台格式，
-                               "embedded" 为嵌入目标 .dll 或 .exe 的
-                               跨平台格式)
- /optimize[+|-]                启用优化(缩写: /o)
- /deterministic                生成确定性的程序集
-                               (包括模块版本 GUID 和时间戳)
- /refonly                      生成引用程序集来替换主要输出
- /instrument:TestCoverage      生成对其检测以收集覆盖率信息的
-                               程序集
- /sourcelink:&lt;file&gt;            要嵌入到可移植 PDB 中的源链接。
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        - 错误和警告 -
- /warnaserror[+|-]             将所有警告报告为错误
- /warnaserror[+|-]:&lt;warn list&gt; 将特定警告报告为错误
- /warn:&lt;n&gt;                     设置警告级别(0-4)(缩写: /w)
- /nowarn:&lt;warn list&gt;           禁用特定警告消息
- /ruleset:&lt;file&gt;               指定禁用特定诊断的
-                               规则集文件。
- /errorlog:&lt;file&gt;              指定用于记录所有编译器和分析器诊断的
-                               文件。
- /reportanalyzer               报告其他分析器信息，如
-                               执行时间。
- 
-                        - 语言 -
- /checked[+|-]                 生成溢出检查
- /unsafe[+|-]                  允许 "unsafe" 代码
- /define:&lt;symbol list&gt;         定义条件编译符号(缩 
-                               写: /d)
- /langversion:&lt;string&gt;         指定语言版本模式: ISO-1、ISO-2、3、
-                               4、5、6、7、7.1、默认或最新模式
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        - 安全 -
- /delaysign[+|-]               仅使用强名称密钥的公共部分对程序集
-                               进行延迟签名
- /publicsign[+|-]              仅使用强名称密钥的公共部分对程序集
-                               进行公共签名
- /keyfile:&lt;file&gt;               指定强名称密钥文件
- /keycontainer:&lt;string&gt;        指定强名称密钥容器
- /highentropyva[+|-]           启用高平均信息量 ASLR
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        - 杂项 -
- @&lt;file&gt;                       读取响应文件以获取更多选项
- /help                         显示此用法消息(缩写: /?)
- /nologo                       取消显示编译器版权消息
- /noconfig                     不自动包括 CSC.RSP 文件
- /parallel[+|-]                并发生成。
- /version                      显示编译器版本号并退出。
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        - 高级 -
- /baseaddress:&lt;address&gt;        要生成的库的基址
- /checksumalgorithm:&lt;alg&gt;      指定计算存储在 PDB 中的源文件
-                               校验和的算法。支持的值是:
-                               SHA1 (默认)或 SHA256。
- /codepage:&lt;n&gt;                 指定打开源文件时要使用的
-                               代码页
- /utf8output                   以 UTF-8 编码格式输出编译器消息
- /main:&lt;type&gt;                  指定包含入口点的类型
-                               (忽略所有其他可能的入口点)(缩 
-                               写: /m)
- /fullpaths                    编译器生成完全限定路径
- /filealign:&lt;n&gt;                指定用于输出文件节的
-                               对齐方式
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
+
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
  /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                               通过编译器指定源路径名称输出的
-                               映射。
- /pdb:&lt;file&gt;                   指定调试信息文件名称(默认: 
-                               具有 .pdb 扩展名的输出文件名)
- /errorendlocation             输出每个错误的结束位置
-                               行和列
- /preferreduilang              指定首选输出语言名称。
- /nostdlib[+|-]                不引用标准库(mscorlib.dll)
- /subsystemversion:&lt;string&gt;    指定此程序集的子系统版本
- /lib:&lt;file list&gt;              指定要在其中搜索引用的附加
-                               目录
- /errorreport:&lt;string&gt;         指定如何处理内部编译器错误:
-                               prompt、send、queue 或 none。默认为
-                               queue。
- /appconfig:&lt;file&gt;             指定包含程序集绑定设置的
-                               应用程序配置文件
- /moduleassemblyname:&lt;string&gt;  此模块所属程序集
-                               的名称
- /modulename:&lt;string&gt;          指定源模块的名称
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
+                               queue.
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3637,7 +3664,7 @@
     <value>无法应用 CallerMemberNameAttribute，因为不存在从类型“{0}”到类型“{1}”的标准转换</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>参数“{0}”不是 ref 或 out 参数，无法按引用返回其成员</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(与前一个错误相关的符号位置)</value>
@@ -3682,7 +3709,7 @@
     <value>无法按引用“{0}”返回参数，因为它不是 ref 或 out 参数</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>命名空间中定义的元素无法显式声明为 private、protected 或 protected internal</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>只有在生成 "module" 目标类型时才能指定 /moduleassemblyname 选项</value>
@@ -3851,6 +3878,9 @@
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>“{0}”定义运算符 == 或运算符 !=，但不重写 Object.GetHashCode()</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>二元运算符的参数之一必须是包含类型</value>
@@ -4315,7 +4345,7 @@
     <value>类型参数“{1}”具有 "struct" 约束，因此“{1}”不能用作“{0}”的约束</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>未定义或导入预定义类型“{0}”</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>类型参数不能是 null</value>
@@ -4480,7 +4510,7 @@
     <value>参数 {0}: 无法从“{1}”转换为“{2}”</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>命名参数规范必须出现在已指定的所有固定参数之后</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>方法“{1}”的类型参数“{0}”的约束必须与接口方法“{3}”的类型参数“{2}”的约束相匹配。请考虑改用显式接口实现。</value>
@@ -5060,6 +5090,9 @@
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>expression-bodied 索引器</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>“{0}”: 无法从动态类型派生</value>

--- a/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.zh-Hant.resx
+++ b/src/Microsoft.CodeAnalysis.CSharp/Microsoft.CodeAnalysis.CSharp.CSharpResources.zh-Hant.resx
@@ -380,6 +380,9 @@
   <data name="WRN_CLS_NoAbstractMembers_Title" xml:space="preserve">
     <value>只有符合 CLS 規範的成員，才可為抽象</value>
   </data>
+  <data name="IDS_FeaturePrivateProtected" xml:space="preserve">
+    <value>private protected</value>
+  </data>
   <data name="ERR_ConflictingMachineModule" xml:space="preserve">
     <value>組件與模組 '{0}' 的目標處理器不可不同。</value>
   </data>
@@ -468,7 +471,7 @@
     <value>'{0}' 未實作 '{1}' 模式，因為 '{2}' 與 '{3}' 之間模稜兩可。</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>/langversion 的選項 '{0}' 無效; 必須為 ISO-1、ISO-2 、Default、Latest 或是範圍 1 到 7.1 之間的有效版本。</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_AliasQualifiedNameNotAnExpression" xml:space="preserve">
     <value>別名限定的名稱不是運算式。</value>
@@ -713,6 +716,9 @@
   <data name="ERR_FloatOverflow" xml:space="preserve">
     <value>浮點常數的值超出類型 '{0}' 的範圍</value>
   </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
+  </data>
   <data name="ERR_EncodinglessSyntaxTree" xml:space="preserve">
     <value>無法在不編碼的情況下，對原始程式文字發出偵錯資訊。</value>
   </data>
@@ -733,6 +739,9 @@
   </data>
   <data name="XML_EndTagExpected" xml:space="preserve">
     <value>必須是元素 '{0}' 的結束標記。</value>
+  </data>
+  <data name="IDS_FeatureLeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_UnexpectedBoundGenericName" xml:space="preserve">
     <value>Nameof 運算子中不可使用類型引數。</value>
@@ -872,11 +881,14 @@
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
     <value>因為組件 '{1}' 的類型 '{0}' 具有屬於內嵌 Interop 類型的泛型類型引數，所以不可跨組件的界限使用。</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
   <data name="ERR_AsMustHaveReferenceType" xml:space="preserve">
     <value>as 運算子必須搭配參考類型或可為 Null 的類型一起使用 ('{0}' 是不可為 Null 的實值類型)</value>
   </data>
   <data name="ERR_AbstractNotVirtual" xml:space="preserve">
-    <value>抽象方法 '{0}' 不可標記為 virtual</value>
+    <value>The abstract {0} '{1}' cannot be marked virtual</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
     <value>'{0}': 靜態類別不可包含使用者定義的運算子</value>
@@ -1028,6 +1040,9 @@
   <data name="WRN_FilterIsConstant" xml:space="preserve">
     <value>篩選條件運算式為常數，請考慮移除此篩選條件。</value>
   </data>
+  <data name="ERR_FeatureNotAvailableInVersion7_2" xml:space="preserve">
+    <value>Feature '{0}' is not available in C# 7.2. Please use language version {1} or greater.</value>
+  </data>
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>C# 7.1 中無法使用 '{0}' 功能。請使用語言版本 {1} 或更高的版本。</value>
   </data>
@@ -1109,6 +1124,9 @@
   <data name="WRN_NewNotRequired" xml:space="preserve">
     <value>成員 '{0}' 並未隱藏可存取的成員。不需要 new 關鍵字。</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="WRN_BadWarningNumber_Description" xml:space="preserve">
     <value>傳遞給 #pragma 警告前置處理器指示詞的號碼不是有效的警告號碼。請驗證號碼代表警告，而不是錯誤。</value>
   </data>
@@ -1126,6 +1144,9 @@
   </data>
   <data name="ERR_ReferenceDirectiveOnlyAllowedInScripts" xml:space="preserve">
     <value>#r 只可用於指令碼中</value>
+  </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
   <data name="SyntaxTreeAlreadyPresent" xml:space="preserve">
     <value>語法樹狀結構已存在</value>
@@ -1322,6 +1343,9 @@
   <data name="ERR_AliasMissingFile" xml:space="preserve">
     <value>參考別名選項無效: '{0}=' -- 遺漏檔案名稱</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_RefReturnReadonly2" xml:space="preserve">
     <value>無法以傳址方式傳回唯讀欄位 '{0}' 的成員</value>
   </data>
@@ -1347,7 +1371,7 @@
     <value>Windows 執行階段事件不可以 out 或 ref 參數形式傳遞。</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>類型 '{0}' 的執行個體不可用於匿名函式、查詢運算式、Iterator 區塊或非同步方法中。</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_CloseUnimplementedInterfaceMemberWrongReturnType" xml:space="preserve">
     <value>'{0}' 未實作介面成員 '{1}'。'{2}' 無法實作 '{1}'，因為其沒有符合的傳回類型 '{3}'。</value>
@@ -1828,7 +1852,7 @@
     <value>遞增或遞減運算子的運算元必須是變數、屬性或索引子。</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>發出可攜式 PDB 時才支援 /embed 參數 (/debug:portable 或 /debug:embedded)。</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="ERR_AbstractAndExtern" xml:space="preserve">
     <value>'{0}' 不可同時為外部與抽象</value>
@@ -3111,8 +3135,8 @@
   <data name="ERR_AmbigMember" xml:space="preserve">
     <value>'{0}' 與 '{1}' 之間模稜兩可</value>
   </data>
-  <data name="ERR_PartialMethodOnlyMethods" xml:space="preserve">
-    <value>只有方法、類別、結構或介面可以是 partial</value>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
   </data>
   <data name="ERR_MissingGuidForOption" xml:space="preserve">
     <value>命令列語法錯誤: 遺漏選項 '{1}' 的 Guid</value>
@@ -3191,143 +3215,146 @@
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
-                              Visual C# 編譯器選項
+                              Visual C# Compiler Options
 
-                        - 輸出檔案 -
- /out:&lt;檔案&gt;                   指定輸出檔案名稱 (預設: 具有主要類別的檔案或
-                               第一個檔案的基底名稱)
- /target:exe                   建置主控台可執行檔 (預設) (簡短 
-                               形式: /t:exe)
- /target:winexe                建置 Windows 可執行檔 (簡短形式: 
+                        - OUTPUT FILES -
+ /out:&lt;file&gt;                   Specify output file name (default: base name of
+                               file with main class or first file)
+ /target:exe                   Build a console executable (default) (Short
+                               form: /t:exe)
+ /target:winexe                Build a Windows executable (Short form:
                                /t:winexe)
- /target:library               建置程式庫 (簡短形式: /t:library)
- /target:module                建置可加入其他組件中的 
-                               模組 (簡短形式: /t:module)
- /target:appcontainerexe       建置 Appcontainer 可執行檔 (簡短形式: 
+ /target:library               Build a library (Short form: /t:library)
+ /target:module                Build a module that can be added to another
+                               assembly (Short form: /t:module)
+ /target:appcontainerexe       Build an Appcontainer executable (Short form:
                                /t:appcontainerexe)
- /target:winmdobj              建置 WinMDExp 所使用的 
-                               Windows 執行階段中繼檔案 (簡短模式: /t:winmdobj)
- /doc:&lt;檔案&gt;                   要產生的 XML 文件檔案
- /refout:&lt;file&gt;                要產生的參考組件輸出
- /platform:&lt;字串&gt;            限制此程式碼可以在哪些平台上執行: x86、
-                               Itanium、x64、arm、anycpu32bitpreferred 或 
-                               anycpu。預設為 anycpu。
+ /target:winmdobj              Build a Windows Runtime intermediate file that
+                               is consumed by WinMDExp (Short form: /t:winmdobj)
+ /doc:&lt;file&gt;                   XML Documentation file to generate
+ /refout:&lt;file&gt;                Reference assembly output to generate
+ /platform:&lt;string&gt;            Limit which platforms this code can run on: x86,
+                               Itanium, x64, arm, anycpu32bitpreferred, or
+                               anycpu. The default is anycpu.
 
-                        - 輸入檔案 -
- /recurse:&lt;萬用字元&gt;           依據指定的萬用字元，包含
-                               目前目錄與子目錄中的所有
-                               檔案
- /reference:&lt;別名&gt;=&lt;檔案&gt;     使用指定的別名，參考指定組件檔
-                               的中繼資料 (簡短形式: /r)
- /reference:&lt;檔案清單&gt;        參考指定組件檔的中繼資料
-                               檔案 (簡短形式: /r)
- /addmodule:&lt;檔案清單&gt;        將指定的模組連結至這個組件
- /link:&lt;檔案清單&gt;             從指定的 Interop 組件檔內嵌
-                               中繼資料 (簡短形式: /l)
- /analyzer:&lt;檔案清單&gt;         從此組件執行分析器
-                               (簡短形式: /a)
- /additionalfile:&lt;檔案清單&gt;   不會直接影響程式碼產生，
-                               但分析器可用以產生錯誤或警告的
-                               其他檔案。
- /embed                        內嵌 PDB 中的所有來源檔案。
- /embed:&lt;檔案清單&gt;            內嵌 PDB 中的特定檔案
+                        - INPUT FILES -
+ /recurse:&lt;wildcard&gt;           Include all files in the current directory and
+                               subdirectories according to the wildcard
+                               specifications
+ /reference:&lt;alias&gt;=&lt;file&gt;     Reference metadata from the specified assembly
+                               file using the given alias (Short form: /r)
+ /reference:&lt;file list&gt;        Reference metadata from the specified assembly
+                               files (Short form: /r)
+ /addmodule:&lt;file list&gt;        Link the specified modules into this assembly
+ /link:&lt;file list&gt;             Embed metadata from the specified interop
+                               assembly files (Short form: /l)
+ /analyzer:&lt;file list&gt;         Run the analyzers from this assembly
+                               (Short form: /a)
+ /additionalfile:&lt;file list&gt;   Additional files that don't directly affect code
+                               generation but may be used by analyzers for producing
+                               errors or warnings.
+ /embed                        Embed all source files in the PDB.
+ /embed:&lt;file list&gt;            Embed specific files in the PDB
 
-                        - 資源 -
- /win32res:&lt;檔案&gt;              指定 Win32 資源檔 (.res)
- /win32icon:&lt;檔案&gt;             將此圖示提供輸出使用
- /win32manifest:&lt;檔案&gt;         指定 Win32 資訊清單檔案 (.xml)
- /nowin32manifest              不包含預設 Win32 資訊清單
- /resource:&lt;resinfo&gt;           內嵌指定的資源 (簡短形式: /res)
- /linkresource:&lt;resinfo&gt;       將指定的資源連結至這個組件 
-                               (簡短形式: /linkres) 其中 resinfo 的格式 
-                               為 &lt;檔案&gt;[,&lt;字串名稱&gt;[,公開|私人]]
+                        - RESOURCES -
+ /win32res:&lt;file&gt;              Specify a Win32 resource file (.res)
+ /win32icon:&lt;file&gt;             Use this icon for the output
+ /win32manifest:&lt;file&gt;         Specify a Win32 manifest file (.xml)
+ /nowin32manifest              Do not include the default Win32 manifest
+ /resource:&lt;resinfo&gt;           Embed the specified resource (Short form: /res)
+ /linkresource:&lt;resinfo&gt;       Link the specified resource to this assembly
+                               (Short form: /linkres) Where the resinfo format
+                               is &lt;file&gt;[,&lt;string name&gt;[,public|private]]
 
-                        - 產生程式碼 -
- /debug[+|-]                   發出偵錯資訊
+                        - CODE GENERATION -
+ /debug[+|-]                   Emit debugging information
  /debug:{full|pdbonly|portable|embedded}
-                               指定偵錯類型 ('full' 為預設，
-                               'portable' 為跨平台格式，
-                               'embedded' 為內嵌 target .dll 或 .exe 中的
-                               跨平台格式)
- /optimize[+|-]                啟用最佳化 (簡短形式: /o)
- /deterministic                產生確定性組件
-                               (包括模組版本 GUID 與時間戳記)
- /refonly                      產生參考組件取代主要輸出
- /instrument:TestCoverage      產生已檢測的組件以收集
-                               涵蓋範圍資訊
- /sourcelink:&lt;檔案&gt;            要內嵌可攜式 PDB 中的來源連結。
+                               Specify debugging type ('full' is default,
+                               'portable' is a cross-platform format,
+                               'embedded' is a cross-platform format embedded into
+                               the target .dll or .exe)
+ /optimize[+|-]                Enable optimizations (Short form: /o)
+ /deterministic                Produce a deterministic assembly
+                               (including module version GUID and timestamp)
+ /refonly                      Produce a reference assembly in place of the main output
+ /instrument:TestCoverage      Produce an assembly instrumented to collect
+                               coverage information
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
-                        - 錯誤及警告 -
- /warnaserror[+|-]             將所有警告回報為錯誤
- /warnaserror[+|-]:&lt;警告清單&gt; 將特定警告回報為錯誤
- /warn:&lt;n&gt;                     設定警告層級 (0-4) (簡短形式: /w)
- /nowarn:&lt;警告清單&gt;           停用特定的警告訊息
- /ruleset:&lt;檔案&gt;               指定可停用特定診斷的
-                               規則集檔案。
- /errorlog:&lt;檔案&gt;              指定要記錄所有編譯器和分析器診斷的
-                               檔案。
- /reportanalyzer               回報其他分析器資訊，例如
-                               執行時間。
- 
-                        - 語言 -
- /checked[+|-]                 產生溢位核對
- /unsafe[+|-]                  允許 'unsafe' 程式碼
- /define:&lt;符號清單&gt;         定義條件式編譯符號 (簡短 
-                               形式: /d)
- /langversion:&lt;字串&gt;         指定語言版本模式: ISO-1、ISO-2、3、
-                               4、5、6、7、7.1、預設或最新
+                        - ERRORS AND WARNINGS -
+ /warnaserror[+|-]             Report all warnings as errors
+ /warnaserror[+|-]:&lt;warn list&gt; Report specific warnings as errors
+ /warn:&lt;n&gt;                     Set warning level (0-4) (Short form: /w)
+ /nowarn:&lt;warn list&gt;           Disable specific warning messages
+ /ruleset:&lt;file&gt;               Specify a ruleset file that disables specific
+                               diagnostics.
+ /errorlog:&lt;file&gt;              Specify a file to log all compiler and analyzer
+                               diagnostics.
+ /reportanalyzer               Report additional analyzer information, such as
+                               execution time.
 
-                        - 安全性 -
- /delaysign[+|-]               只使用強式名稱金鑰的公開部分
-                               延遲簽署組件
- /publicsign[+|-]              只使用強式名稱金鑰的公開
-                               部分公開簽署組件
- /keyfile:&lt;檔案&gt;               指定強式名稱金鑰檔
- /keycontainer:&lt;字串&gt;        指定強式名稱金鑰容器
- /highentropyva[+|-]           啟用高度 Entropy ASLR
+                        - LANGUAGE -
+ /checked[+|-]                 Generate overflow checks
+ /unsafe[+|-]                  Allow 'unsafe' code
+ /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
+                               form: /d)
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `6` or `7.1`
 
-                        - 其他 -
- @&lt;檔案&gt;                       讀取回應檔以取得更多選項
- /help                         顯示本使用方式訊息 (簡短形式: /?)
- /nologo                       隱藏編譯器著作權訊息
- /noconfig                     不要自動包含 CSC.RSP 檔案
- /parallel[+|-]                並行建置。
- /version                      顯示編譯器版本號碼並結束。
+                        - SECURITY -
+ /delaysign[+|-]               Delay-sign the assembly using only the public
+                               portion of the strong name key
+ /publicsign[+|-]              Public-sign the assembly using only the public
+                               portion of the strong name key
+ /keyfile:&lt;file&gt;               Specify a strong name key file
+ /keycontainer:&lt;string&gt;        Specify a strong name key container
+ /highentropyva[+|-]           Enable high-entropy ASLR
 
-                        - 進階 -
- /baseaddress:&lt;位址&gt;        要建置的程式庫基底位址
- /checksumalgorithm:&lt;alg&gt;      為計算儲存在 PDB 中的原始程式檔總和檢查碼
-                               指定演算法。支援的值為:
-                               SHA1 (預設) 或 SHA256。
- /codepage:&lt;n&gt;                 指定開啟原始程式檔時要使用的
-                               字碼頁
- /utf8output                   以 UTF-8 編碼方式輸出編譯器訊息
- /main:&lt;類型&gt;                  指定包含進入點
-                               (忽略所有其他可能的進入點) 的類型 (簡短 
-                               形式: /m)
- /fullpaths                    編譯器產生完整路徑
- /filealign:&lt;n&gt;                指定用於輸出檔案區段的
-                               對齊
+                        - MISCELLANEOUS -
+ @&lt;file&gt;                       Read response file for more options
+ /help                         Display this usage message (Short form: /?)
+ /nologo                       Suppress compiler copyright message
+ /noconfig                     Do not auto include CSC.RSP file
+ /parallel[+|-]                Concurrent build.
+ /version                      Display the compiler version number and exit.
+
+                        - ADVANCED -
+ /baseaddress:&lt;address&gt;        Base address for the library to be built
+ /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file
+                               checksum stored in PDB. Supported values are:
+                               SHA1 (default) or SHA256.
+ /codepage:&lt;n&gt;                 Specify the codepage to use when opening source
+                               files
+ /utf8output                   Output compiler messages in UTF-8 encoding
+ /main:&lt;type&gt;                  Specify the type that contains the entry point
+                               (ignore all other possible entry points) (Short
+                               form: /m)
+ /fullpaths                    Compiler generates fully qualified paths
+ /filealign:&lt;n&gt;                Specify the alignment used for output file
+                               sections
  /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                               為編譯器輸出的來源路徑名稱
-                               指定對應。
- /pdb:&lt;檔案&gt;                   指定偵錯資訊檔案名稱 (預設: 
-                               副檔名為 .pdb 的輸出檔案名稱)
- /errorendlocation             輸出每個錯誤之結束位置的
-                               行與欄
- /preferreduilang              指定慣用的輸出語言名稱。
- /nostdlib[+|-]                不要參考標準程式庫 (mscorlib.dll)
- /subsystemversion:&lt;字串&gt;    指定這個組件的子系統版本
- /lib:&lt;檔案清單&gt;              指定要搜尋的其他目錄以供
-                               參考
- /errorreport:&lt;字串&gt;         指定如何處理內部編譯器錯誤: 
-                               prompt、send、queue 或 none。預設為 
-                               queue。
- /appconfig:&lt;檔案&gt;             指定包含組件繫結設定的
-                               應用程式設定檔
- /moduleassemblyname:&lt;字串&gt;  組件名稱，其中將包含
-                               此模組
- /modulename:&lt;字串&gt;          指定來源模組的名稱
+                               Specify a mapping for source path names output by
+                               the compiler.
+ /pdb:&lt;file&gt;                   Specify debug information file name (default:
+                               output file name with .pdb extension)
+ /errorendlocation             Output line and column of the end location of
+                               each error
+ /preferreduilang              Specify the preferred output language name.
+ /nostdlib[+|-]                Do not reference standard library (mscorlib.dll)
+ /subsystemversion:&lt;string&gt;    Specify subsystem version of this assembly
+ /lib:&lt;file list&gt;              Specify additional directories to search in for
+                               references
+ /errorreport:&lt;string&gt;         Specify how to handle internal compiler errors:
+                               prompt, send, queue, or none. The default is
+                               queue.
+ /appconfig:&lt;file&gt;             Specify an application configuration file
+                               containing assembly binding settings
+ /moduleassemblyname:&lt;string&gt;  Name of the assembly which this module will be
+                               a part of
+ /modulename:&lt;string&gt;          Specify the name of the source module
 </value>
   </data>
   <data name="ERR_ValueExpected" xml:space="preserve">
@@ -3637,7 +3664,7 @@
     <value>無法套用 CallerMemberNameAttribute，因為沒有從類型 '{0}' 標準轉換成類型 '{1}'。</value>
   </data>
   <data name="ERR_RefReturnParameter2" xml:space="preserve">
-    <value>無法以傳址方式傳回參數 '{0}' 的成員，因為其非 ref 或 out 參數</value>
+    <value>Cannot return a member of parameter '{0}' by reference because it is not a ref or out parameter</value>
   </data>
   <data name="IDS_RELATEDERROR" xml:space="preserve">
     <value>(與之前錯誤相關符號的位置)</value>
@@ -3682,7 +3709,7 @@
     <value>無法以傳址方式 '{0}' 傳回參數，因為其非 ref 或 out 參數</value>
   </data>
   <data name="ERR_NoNamespacePrivate" xml:space="preserve">
-    <value>無法明確宣告在命名空間中定義的項目為 private、protected 或 protected internal</value>
+    <value>Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected</value>
   </data>
   <data name="ERR_AssemblyNameOnNonModule" xml:space="preserve">
     <value>只有在建置 'module' 的目標類型時，才可指定 /moduleassemblyname 選項。</value>
@@ -3851,6 +3878,9 @@
   </data>
   <data name="WRN_EqualityOpWithoutGetHashCode" xml:space="preserve">
     <value>'{0}' 定義了運算子 == 或運算子 !=，但不會覆寫 Object.GetHashCode()。</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_BadBinaryOperatorSignature" xml:space="preserve">
     <value>二元運算子的一個參數必須為包含類型</value>
@@ -4315,7 +4345,7 @@
     <value>類型參數 '{1}' 有 'struct' 條件約束，因此 '{1}' 不可做為 '{0}' 的條件約束。</value>
   </data>
   <data name="ERR_PredefinedValueTupleTypeNotFound" xml:space="preserve">
-    <value>未定義或匯入預先定義的類型 '{0}'</value>
+    <value>Predefined type '{0}' is not defined or imported, or is declared in multiple referenced assemblies</value>
   </data>
   <data name="TypeArgumentCannotBeNull" xml:space="preserve">
     <value>類型引數不可為 null</value>
@@ -4480,7 +4510,7 @@
     <value>引數 {0}: 無法從 '{1}' 轉換成 '{2}'</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>具名引數規格必須出現在所有已指定的固定引數之後</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>方法 '{1}' 之類型參數 '{0}' 的條件約束，必須符合介面方法 '{3}' 之類型參數 '{2}' 的條件約束。請考慮改用明確的介面實作。</value>
@@ -5060,6 +5090,9 @@
   </data>
   <data name="IDS_FeatureExpressionBodiedIndexer" xml:space="preserve">
     <value>運算式主體索引子</value>
+  </data>
+  <data name="ERR_LocalFunctionMissingBody" xml:space="preserve">
+    <value>'{0}' is a local function and must therefore always have a body.</value>
   </data>
   <data name="ERR_DeriveFromDynamic" xml:space="preserve">
     <value>'{0}': 無法衍生自動態類型</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.cs.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.cs.resx
@@ -447,7 +447,7 @@
     <value>Odkaz na sestavení {0} je neplatný a nedá se vyhodnotit.</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>Lze zadat jenom jedno z klíčových slov Public, Private, Protected, Friend nebo Protected Friend.</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>Výraz lambda se z této obslužné rutiny události neodebere.</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>{0} má stejný název, jako jiný člen použil pro typ {1} vystavený ve skupině My. Přejmenujte typ nebo obor názvů, v němž je obsažený.</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>{0} není událost v {1}.</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>Typ {0} nejde v tomto kontextu použít, protože {0} je parametrem typu Out.</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>{0} a {1} se nemůžou vzájemně přetěžovat, protože jenom v jedné deklaraci je uvedené klíčové slovo Default.</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>Společný typ nejde odvodit, protože je přípustný více než jeden typ; předpokládá se typ Object.</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>Očekávala se řetězcová konstanta.</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>Příkazy ReDim vyžadují seznam nových mezí jednotlivých rozměrů pole uvedený v závorkách.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>Atribut {0} nejde použít pro člena {1} v {2}, protože není platný pro tento deklarovaný typ.</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>Příkazu End Set musí předcházet párový příkaz Set.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Přepínač /embed se podporuje jenom při generování souboru PDB typu Portable (/debug:portable nebo /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>Rozhraní {0} je nejednoznačné s jiným implementovaným rozhraním {1} kvůli parametrům In a Out v {2}.</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>Příkaz se nemůže objevit v těle rozhraní.</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>{0} není parametr metody.</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>Příkaz Continue While se dá použít jenom v rámci příkazu While.</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>Metoda rozšíření {0} definovaná v {1} má příliš moc argumentů.</value>
@@ -3955,7 +3973,7 @@
     <value>Metoda nemůže mít současně parametr ParamArray i Optional.</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>Pro metodu ve struktuře nejde použít deklaraci Protected ani Protected Friend.</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>Předpokládá se, že proměnná rozsahu je typu Objekt, protože její typ nejde odvodit. Zadejte jiný typ pomocí klauzule As.</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>Deklaraci MustInherit nejde zadat pro částečný typ {0}, protože ji nejde kombinovat s deklarací NotInheritable zadanou pro jeden z jejích ostatních částečných typů.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>V události prostředí Windows Runtime musí být parametr metody RemoveHandler typu EventRegistrationToken.</value>
@@ -4325,162 +4346,164 @@
     <value>Očekávalo se klíčové slovo Is.</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Možnosti kompilátoru Visual Basic
+    <value>                  Visual Basic Compiler Options
 
-                                  - VÝSTUPNÍ SOUBOR -
-/out:&lt;soubor&gt;                     Určuje název výstupního souboru.
-/target:exe                       Vytvoří konzolovou aplikaci (výchozí).
-                                  (Krátký tvar: /t)
-/target:winexe                    Vytvoří aplikaci Windows.
-/target:library                   Vytvoří sestavení knihovny.
-/target:module                    Vytvoří modul, který jde přidat
-                                  do sestavení.
-/target:appcontainerexe           Vytvoří aplikaci Windows, která bude běžet
-                                  v kontejneru AppContainer.
-/target:winmdobj                  Vytvoří pomocný soubor metadat Windows.
-/doc[+|-]                         Generuje soubor dokumentace XML.
-/doc:&lt;soubor&gt;                     Generuje soubor dokumentace XML s určeným názvem.
-/refout:&lt;file&gt;                    Výstup referenčního sestavení, který se bude generovat
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
+                                  assembly.
+/target:appcontainerexe           Create a Windows application that runs in 
+                                  AppContainer.
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - VSTUPNÍ SOUBORY -
-/addmodule:&lt;seznam_souborů&gt;       Odkazuje na metadata ze zadaných modulů.
-/link:&lt;seznam_souborů&gt;            Vloží metadata ze zadaného definičního
-                                  sestavení. (Krátký tvar: /l)
-/recurse:&lt;zástupný_znak&gt;          Zahrne všechny soubory v aktuálním adresáři
-                                  a podadresářích podle zadaného
-                                  zástupného znaku.
-/reference:&lt;seznam_souborů&gt;       Odkazuje na metadata ze zadaného
-                                  sestavení. (Krátký tvar: /r)
-/analyzer:&lt;seznam_souborů&gt;        Spustí analyzátory z tohoto sestavení.
-                                  (Krátký tvar: /a)
-/additionalfile:&lt;seznam_souborů&gt;  Další soubory, které přímo neovlivňují generování
-                                  kódu, ale analyzátory můžou jejich pomocí
-                                  produkovat chyby nebo upozornění.
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - PROSTŘEDKY -
-/linkresource:&lt;prostředek&gt;        Připojí zadaný soubor jako externí prostředek
-                                  sestavení.
-                                  prostředek: &lt;soubor&gt;[,&lt;název&gt;[,public|private]]
-                                  (Krátký tvar: /linkres)
-/nowin32manifest                  Výchozí manifest by se neměl vkládat
-                                  do oddílu manifestu výstupního PE.
-/resource:&lt;prostředek&gt;            Přidá zadaný soubor jako vložený prostředek
-                                  sestavení.
-                                  prostředek: &lt;soubor&gt;[,&lt;název&gt;[,public|private]]
-                                  (Krátký tvar: /res)
-/win32icon:&lt;soubor&gt;               Určuje soubor ikony Win32 (.ico) pro
-                                  výchozí prostředky Win32.
-/win32manifest:&lt;soubor&gt;           Zadaný soubor se vloží do oddílu
-                                  manifestu výstupního PE.
-/win32resource:&lt;soubor&gt;           Určuje soubor prostředků Win32 (.res).
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - GENEROVÁNÍ KÓDU -
-/optimize[+|-]                    Povolí optimalizace.
-/removeintchecks[+|-]             Odebere kontroly celých čísel. Standardně vypnuté.
-/debug[+|-]                       Generuje ladicí informace.
-/debug:full                       Generuje úplné ladicí informace (výchozí).
-/debug:pdbonly                    Generuje úplné ladicí informace.
-/debug:portable                   Generuje ladicí informace napříč platformami.
-/debug:embedded                   Generuje ladicí informace napříč platformami
-                                  do cílového souboru .dll nebo .exe.
-/deterministic                    Vytvoří deterministické sestavení
-                                  (včetně GUID verze modulu a časového razítka).
-/refonly                          Vytvoří referenční sestavení na místě hlavního výstupu.
-/instrument:TestCoverage          Vytvoří sestavení instrumentované pro shromažďování informací
-                                  o pokrytí.
-/sourcelink:&lt;soubor&gt;              Informace o zdrojovém odkazu vkládané do přenosného PDB.
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - CHYBY A UPOZORNĚNÍ -
-/nowarn                           Zakáže všechna upozornění.
-/nowarn:&lt;seznam_čísel&gt;            Zakáže upozornění ze seznamu.
-/warnaserror[+|-]                 Zpracuje všechna upozornění jako chyby.
-/warnaserror[+|-]:&lt;seznam_čísel&gt;  Zpracuje zadaná upozornění jako chyby.
-/ruleset:&lt;soubor&gt;                 Určuje soubor sady pravidel, která zakazuje
-                                  specifickou diagnostiku.
-/errorlog:&lt;soubor&gt;                Určuje soubor pro protokolování veškeré diagnostiky
-                                  kompilátoru a analyzátoru.
-/reportanalyzer                   Oznamuje další informace analyzátoru, jako třeba
-                                  dobu zpracování.
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-                                  - JAZYK -
-/define:&lt;seznam_symbolů&gt;          Deklaruje globální symboly podmíněné
-                                  kompilace. seznam_symbolů: název=hodnota,...
-                                  (Krátký tvar: /d)
-/imports:&lt;seznam_importů&gt;         Deklaruje globální importy pro obory názvů
-                                  v odkazovaných souborech metadat.
-                                  seznam_importů: obor_názvů,...
-/langversion:&lt;číslo&gt;              Určuje jazykovou verzi:
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest
-/optionexplicit[+|-]              Vyžaduje explicitní deklarování proměnných.
-/optioninfer[+|-]                 Povoluje odvození typu proměnných.
-/rootnamespace:&lt;řetězec&gt;          Určuje kořenový obor názvů pro všechny
-                                  deklarace typů.
-/optionstrict[+|-]                Vynucuje striktní sémantiku jazyka.
-/optionstrict:custom              Upozorňuje na nedodržování striktní
-                                  sémantiky jazyka.
-/optioncompare:binary             Určuje binární styl porovnávání řetězců.
-                                  Jde o výchozí možnost.
-/optioncompare:text               Určuje textový styl porovnávání řetězců.
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
+                                  import_list:namespace,...
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - RŮZNÉ -
-/help                             Zobrazí tuto zprávu o použití. (Krátký tvar: /?)
-/noconfig                         Nezahrnuje automaticky soubor VBC.RSP.
-/nologo                           Nezobrazí zprávu o autorských právech kompilátoru.
-/quiet                            Určuje tichý výstupní režim.
-/verbose                          Zobrazí podrobné zprávy.
-/parallel[+|-]                    Souběžné sestavení 
-/version                          Zobrazí číslo verze kompilátoru a ukončí se.
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - POKROČILÉ -
-/baseaddress:&lt;číslo&gt;              Určuje základní adresu pro knihovnu nebo
-                                  modul (hex).
-/checksumalgorithm:&lt;alg&gt;          Určuje algoritmus pro výpočet kontrolního součtu
-                                  zdrojového souboru uloženého v PDB. Podporované
-                                  hodnoty jsou SHA1 (výchozí) nebo SHA256.
-/codepage:&lt;číslo&gt;                 Určuje znakovou stránku, která se má použít
-                                  při otevírání zdrojových souborů.
-/delaysign[+|-]                   Vytvoří zpožděný podpis sestavení s využitím
-                                  veřejné části klíče silného názvu.
-/publicsign[+|-]                  Vytvoří veřejný podpis sestavení s využitím jenom veřejné
-                                  části klíče silného názvu.
-/errorreport:&lt;řetězec&gt;            Určuje způsob zpracování interních chyb
-                                  kompilátoru: prompt, send, none nebo queue
-                                  (výchozí).
-/filealign:&lt;číslo&gt;                Určuje zarovnání použité pro oddíly výstupního
-                                  souboru.
-/highentropyva[+|-]               Povoluje ASLR s vysokou entropií.
-/keycontainer:&lt;řetězec&gt;           Určuje kontejner klíče se silným názvem.
-/keyfile:&lt;soubor&gt;                 Určuje soubor klíče se silným názvem.
-/libpath:&lt;seznam_cest&gt;            Seznam adresářů, kde se mají hledat odkazy
-                                  na metadata (oddělený středníky)
-/main:&lt;třída&gt;                     Určuje třídu nebo modul obsahující
-                                  Sub Main. Může to být taky třída, která
-                                  dědí od System.Windows.Forms.Form.
-                                  (Krátký tvar: /m)
-/moduleassemblyname:&lt;řetězec&gt;     Určuje název sestavení, jehož součástí bude
-                                  tento modul.
-/netcf                            Cílí na .NET Compact Framework.
-/nostdlib                         Neodkazuje na standardní knihovny
-                                  (system.dll a VBC.RSP).
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
+                                  (hex).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
 /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                                  Určuje mapování pro výstup zdrojových názvů cest
-                                  kompilátorem.
-/platform:&lt;řetězec&gt;                Omezuje platformy, na kterých se dá tento kód
-                                  spustit: x86, x64, Itanium, arm,
-                                  AnyCPU32BitPreferred nebo anycpu (výchozí).
-/preferreduilang                  Určuje název upřednostňovaného výstupního jazyka.
-/sdkpath:&lt;cesta&gt;                  Umístění adresáře s .NET Framework SDK
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
                                   (mscorlib.dll).
-/subsystemversion:&lt;verze&gt;         Určuje verzi subsystému výstupního PE.
-                                  verze: &lt;číslo&gt;[.&lt;číslo&gt;]
-/utf8output[+|-]                  Generuje výstup kompilátoru v kódování
-                                  UTF-8.
-@&lt;soubor&gt;                         Vloží nastavení příkazového řádku ze souboru.
-/vbruntime[+|-|*]                 Kompiluje s výchozím modulem runtime nebo bez něj
-                                  Visual Basicu.
-/vbruntime:&lt;soubor&gt;               Kompiluje s alternativním modulem runtime
-                                  Visual Basicu určeným parametrem &lt;soubor&gt;.
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
+                                  version:&lt;number&gt;[.&lt;number&gt;]
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4493,7 +4516,7 @@
     <value>{0} nemůže přepsat {1}, protože se liší v omezeních parametrů typu.</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>Očekával se pojmenovaný argument.</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>Konstanta {0} nemůže záviset na vlastní hodnotě.</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.de.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.de.resx
@@ -447,7 +447,7 @@
     <value>Der Assemblyverweis "{0}" ist ungültig und kann nicht aufgelöst werden.</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>Nur "Public", "Private", "Protected", "Friend" oder "Protected Friend" können angegeben werden.</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>Der Lambdaausdruck wird aus diesem Ereignishandler nicht entfernt.</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>"{0}" hat den gleichen Namen wie ein Member, der für den in einer My-Gruppe verfügbar gemachter Typ "{1}" verwendet wird. Benennen Sie den Typ oder den einschließenden Namespace um.</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>"{0}" ist kein Ereignis von "{1}".</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>Der Typ "{0}" kann nicht in diesem Kontext verwendet werden, weil "{0}" ein Parameter vom Typ "Out" ist.</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>"{0}" und "{1}" können sich nicht gegenseitig überladen, da nur eine als "Default" deklariert ist.</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>Es kann kein gemeinsamer Typ abgeleitet werden, weil mehrere Typen möglich sind. "Object" wird angenommen.</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>Zeichenfolgenkonstante erwartet.</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>ReDim-Anweisungen erfordern eine in Klammern gesetzte Liste der neuen Grenzen jeder Arraydimension.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>Das Attribut "{0}" kann nicht auf "{1}" von "{2}" angewendet werden, da das Attribut für diesen Deklarationstyp nicht gültig ist.</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>"End Set" muss ein entsprechendes "Set" voranstehen.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Der Schalter "/embed" wird nur unterstützt, wenn portable PDB-Dateien ausgegeben werden ("/debug:portable" oder "/debug:embedded").</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>Die Schnittstelle "{0}" unterscheidet sich aufgrund der Parameter "In" und "Out" in "{2}" nicht eindeutig von einer anderen implementierten Schnittstelle ({1}).</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>Die Anweisung kann nicht innerhalb des Schnittstellentexts verwendet werden.</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>"{0}" ist kein Methodenparameter.</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>Continue While darf nur innerhalb einer While-Anweisung verwendet werden.</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>Zu viele Argumente für die in "{1}" definierte Erweiterungsmethode "{0}".</value>
@@ -3955,7 +3973,7 @@
     <value>Die Methode kann nicht über einen ParamArray-Parameter und einen Optional-Parameter verfügen.</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>Eine Methode in einer Struktur kann nicht als "Protected" oder "Protected Friend" deklariert werden.</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>Für die Bereichsvariable wird der Typ "Object" angenommen, da ihr Typ nicht durch Rückschluss abgeleitet werden kann. Verwenden Sie eine As-Klausel, um einen anderen Typ anzugeben.</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>"MustInherit" kann nicht für den partiellen Typ "{0}" angegeben werden, da "NotInheritable" für einen der anderen partiellen Typen angegeben wurde und eine Kombination nicht möglich ist.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>Bei einem Windows-Runtime-Ereignis muss der Methodenparameter "RemoveHandler" vom Typ "EventRegistrationToken" sein.</value>
@@ -4325,162 +4346,164 @@
     <value>"Is" erwartet.</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Visual Basic-Compileroptionen
+    <value>                  Visual Basic Compiler Options
 
-                                  - AUSGABEDATEI -
-/out:&lt;Datei&gt;                       Gibt den Ausgabedateinamen an.
-/target:exe                       Erstellt eine Konsolenanwendung (Standardwert). 
-                                  (Kurzform: /t)
-/target:winexe                    Erstellt eine Windows-Anwendung.
-/target:library                  Erstellt eine Bibliotheksassembly.
-/target:module                    Erstellt ein Modul, das einer Assembly 
-                                  hinzugefügt werden kann.
-/target:appcontainerexe           Erstellt eine Windows-Anwendung, die in
-                                  AppContainer ausgeführt wird.
-/target:winmdobj                  Erstellt eine Windows-Metadatenzwischendatei.
-/doc[+|-]                         Generiert eine XML-Dokumentationsdatei.
-/doc:&lt;Datei&gt;                       Generiert eine XML-Dokumentationsdatei in &lt;Datei&gt;.
-/refout:&lt;Datei&gt;                    Zu generierende Referenzassemblyausgabe
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
+                                  assembly.
+/target:appcontainerexe           Create a Windows application that runs in 
+                                  AppContainer.
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - EINGABEDATEIEN -
-/addmodule:&lt;Dateiliste&gt;            Verweist auf Metadaten aus den angegebenen Modulen.
-/link:&lt;Dateiliste&gt;                 Bettet Metadaten aus der angegebenen Interop-
-                                  assembly ein. (Kurzform: /l)
-/recurse:&lt;Platzhalter&gt;               Schließt alle Dateien im aktuellen Verzeichnis
-                                  und dessen Unterverzeichnissen gemäß den
-                                  Platzhalterspezifikationen ein.
-/reference:&lt;Dateiliste&gt;            Verweist auf Metadaten aus der angegebenen
-                                  Assembly. (Kurzform: /r)
-/analyzer:&lt;Dateiliste&gt;             Führt die Analyzer aus dieser Assembly aus.
-                                  (Kurzform: /a)
-/additionalfile:&lt;Dateiliste&gt;       Zusätzliche Dateien, die sich nicht direkt auf die Code-
-                                  generierung auswirken, aber ggf. von Analyzern zum Erstellen von
-                                  Fehlern oder Warnungen verwendet werden können.
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - RESSOURCEN -
-/linkresource:&lt;resinfo&gt;           Verknüpft die angegebene Datei als eine externe 
-                                  Assemblyressource.
-                                  resinfo:&lt;Datei&gt;[,&lt;Name&gt;[,public|private]] 
-                                  (Kurzform: /linkres)
-/nowin32manifest                  Das Standardmanifest soll nicht in den
-                                  Manifestabschnitt der PE-Ausgabedatei eingebettet werden.
-/resource:&lt;resinfo&gt;               Fügt die angegebene Datei als eine eingebettete
-                                  Assemblyressource hinzu.
-                                  resinfo:&lt;Datei&gt;[,&lt;Name&gt;[,public|private]] 
-                                  (Kurzform: /res)
-/win32icon:&lt;Datei&gt;                 Gibt eine Win32-Symboldatei (ICO-Datei) für die
-                                  Win32-Standardressourcen an.
-/win32manifest:&lt;Datei&gt;             Die angegebene Datei wird im Manifest-
-                                  abschnitt der PE-Ausgabedatei eingebettet.
-/win32resource:&lt;Datei&gt;             Gibt eine Win32-Ressourcendatei (RES-Datei) an.
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - CODEGENERIERUNG -
-/optimize[+|-]                    Aktiviert Optimierungen.
-/removeintchecks[+|-]             Entfernt Integerüberprüfungen. Standardmäßig deaktiviert.
-/debug[+|-]                       Gibt Debuginformationen aus.
-/debug:full                       Gibt vollständige Debuginformationen aus (Standardeinstellung).
-/debug:pdbonly                    Gibt vollständige Debuginformationen aus.
-/debug:portable                   Gibt plattformübergreifende Debuginformationen aus.
-/debug:embedded                   Gibt plattformübergreifende Debuginformationen in
-                                  die Ziel-DLL oder -EXE aus.
-/deterministic                    Generiert eine deterministische Assembly
-                                  (einschließlich Modulversion-GUID und Zeitstempel)
-/refonly                          Erstellt eine Referenzassembly anstelle der Hauptausgabe
-/instrument:TestCoverage          Erstellt eine Assembly, die zum Erfassen von Abdeckungsinformationen
-                                  instrumentiert ist.
-/sourcelink:&lt;Datei&gt;                Quelllinkinformationen, die in die PDB-Datei eingebettet werden sollen.
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - FEHLER UND WARNUNGEN -
-/nowarn                           Deaktiviert alle Warnungen.
-/nowarn:&lt;Zahlenliste&gt;             Deaktiviert eine Liste einzelner Warnungen.
-/warnaserror[+|-]                 Behandelt alle Warnungen als Fehler.
-/warnaserror[+|-]:&lt;Zahlenliste&gt;   Behandelt eine Liste von Warnungen als Fehler.
-/ruleset:&lt;Datei&gt;                   Gibt eine Regelsatzdatei an, die bestimmte
-                                  Diagnosefunktionen deaktiviert.
-/errorlog:&lt;Datei&gt;                  Gibt eine Datei an, in der alle Compiler- und Analyzer-
-                                  diagnosedaten protokolliert werden.
-/reportanalyzer                   Meldet zusätzliche Analyzerinformationen, z. B.
-                                  die Ausführungszeit.
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-                                  - SPRACHE -
-/define:&lt; Symbolliste &gt;             Deklariert globale bedingte Kompilierung von
-                                  Symbolen. symbol_list:name=value,... 
-                                  (Kurzform: /d)
-/imports:&lt; Importliste &gt;            Deklariert globale Importe für Namespaces in 
-                                  Metadatendateien, auf die verwiesen wird. 
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
                                   import_list:namespace,...
-/langversion:&lt;Zahl&gt;             Gibt die Sprachversion an: 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest
-/optionexplicit[+|-]              Erfordert die explizite Deklaration von Variablen.
-/optioninfer[+|-]                 Lässt den Typrückschluss von Variablen zu.
-/rootnamespace:&lt;Zeichenfolge&gt;           Gibt den Stammnamespace für alle Typ-
-                                  deklarationen an.
-/optionstrict[+|-]                Erzwingt strenge Sprachsemantik.
-/optionstrict:custom              Warnt, wenn die strenge Sprachsemantik nicht
-                                  beachtet wird.
-/optioncompare:binary             Gibt Zeichenfolgenvergleiche im Binärstil an.
-                                  Dies ist die Standardeinstellung.
-/optioncompare:text               Gibt Zeichenfolgenvergleiche im Textstil an.
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - SONSTIGES -
-/help                             Zeigt diese Syntaxinformationen an. (Kurzform: /?)
-/noconfig                         Schließt die VBC.RSP-Datei nicht automatisch ein.
-/nologo                           Zeigt das Compilercopyrightbanner nicht an.
-/quiet                            Stiller Ausgabemodus.
-/verbose                          Zeigt ausführliche Meldungen an.
-/parallel[+|-]                    Gleichzeitige Erstellung. 
-/version                          Zeigt die Compilerversionsnummer und die Beendigung an.
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - ERWEITERT -
-/baseaddress:&lt;Zahl&gt;             Die Basisadresse für eine Bibliothek oder ein Modul
-                                  (hexadezimal).
-/checksumalgorithm:&lt;alg&gt;          Legt den Algorithmus zum Berechnen der Quelldatei-
-                                  prüfsumme fest, die in der PDB-Datei gespeichert ist. Unterstützte Werte sind:
-                                  SHA1 (Standard) oder SHA256.
-/codepage:&lt;Zahl&gt;                Gibt die Codepage an, die beim Öffnen von
-                                  Quelldateien verwendet werden soll.
-/delaysign[+|-]                   Signiert die Assembly verzögert nur mithilfe des öffentlichen
-                                  Teils des Schlüssels für einen starken Namen.
-/publicsign[+|-]                  Signiert die Assembly öffentlich nur mithilfe des öffentlichen
-                                  Teils des Schlüssels für einen starken Namen.
-/errorreport:&lt;Zeichenfolge&gt;             Gibt an, wie interne Compiler-
-                                                                    fehler behandelt werden. Mögliche Werte sind "prompt", "send", "none" oder "queue"
-                                  (Standardwert).
-/filealign:&lt;Zahl&gt;               Gibt die Ausrichtung an, die für die Abschnitte der
-                                  Ausgabedatei verwendet wird.
-/highentropyva[+|-]               Aktiviert ASLR mit hoher Entropie.
-/keycontainer:&lt;Zeichenfolge&gt;            Gibt einen Schlüsselcontainer mit starkem Namen an.
-/keyfile:&lt;Datei&gt;                   Gibt eine Schlüsseldatei mit starkem Namen an.
-/libpath:&lt;Pfadliste&gt;              Die Liste der Verzeichnisse, die nach Metadaten-
-                                  verweisen durchsucht werden sollen (durch Semikolons getrennt).
-/main:&lt;Klasse&gt;                     Gibt die Klasse oder das Modul an, die bzw. das
-                                  "Sub Main" enthält. Es kann sich auch um eine Klasse handeln, 
-                                  die von "System.Windows.Forms.Form" erbt. 
-                                  (Kurzform: /m)
-/moduleassemblyname:&lt;Zeichenfolge&gt;      Der Name der Assembly, zu der dieses Modul 
-                                  gehören wird.
-/netcf                            Gibt .NET Compact Framework als Ziel an.
-/nostdlib                         Keine Verweise auf Standardbibliotheken
-                                  ("system.dll" und VBC.RSP-Datei).
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
+                                  (hex).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
 /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                                  Gibt eine Zuordnung für die Ausgabe der Quellpfadnamen durch
-                                  den Compiler an.
-/platform:&lt;Zeichenfolge&gt;                Schränkt die Plattformen ein, auf denen dieser Code ausgeführt werden kann; 
-                                  gültige Werte sind x86, x64, Itanium, arm,
-                                  AnyCPU32BitPreferred oder anycpu (Standard).
-/preferreduilang                  Gibt den Namen der bevorzugten Ausgabesprache an.
-/sdkpath:&lt;Pfad&gt;                   Der Speicherort des .NET Framework SDK-Verzeichnisses
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
                                   (mscorlib.dll).
-/subsystemversion:&lt;Version&gt;       Gibt die Subsystemversion der PE-Ausgabedatei an. 
-                                  version:&lt;Zahl&gt;[.&lt;Zahl&gt;]
-/utf8output[+|-]                  Gibt die Compilerausgabe in UTF8-Zeichen-
-                                  codierung aus.
-@&lt;Datei&gt;                           Fügt Befehlszeileneinstellungen aus einer Textdatei ein.
-/vbruntime[+|-|*]                 Kompiliert mit der bzw. ohne die Visual Basic-
-                                  Standardlaufzeit.
-/vbruntime:&lt;Datei&gt;                 Kompiliert mit der Visual Basic-
-                                  Alternativlaufzeit in &lt;Datei&gt;.
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
+                                  version:&lt;number&gt;[.&lt;number&gt;]
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4493,7 +4516,7 @@
     <value>"{0}" kann "{1}" nicht überschreiben, da sie unterschiedliche Typparametereinschränkungen aufweisen.</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>Benanntes Argument erwartet.</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>Die Konstante "{0}" kann nicht von ihrem eigenen Wert abhängen.</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.es.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.es.resx
@@ -447,7 +447,7 @@
     <value>La referencia de ensamblado '{0}' no es válida y no se puede resolver.</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>Solo se puede especificar 'Public', 'Private', 'Protected', 'Friend' o 'Protected Friend'.</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>La expresión lambda no se quitará de este controlador de eventos</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>'{0}' tiene el mismo nombre que un miembro usado para el tipo '{1}' expuesto en un grupo 'My'. Cambie el nombre del tipo o de su espacio de nombres envolvente.</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>'{0}' no es un evento de '{1}'.</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>No se puede usar el tipo '{0}' en este contexto porque '{0}' es un parámetro de tipo 'Out'.</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>'{0}' y '{1}' no se pueden sobrecargar el uno al otro debido a que solo uno está marcado como 'Default'.</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>No se puede inferir un tipo común porque es posible más de un tipo; se supone 'Object'.</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>Se esperaba una constante de cadena.</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>Las instrucciones 'ReDim' requieren una lista entre paréntesis de los nuevos límites de cada una de las dimensiones de la matriz.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>El atributo '{0}' no se puede aplicar a '{1}' de '{2}' porque el atributo no es válido en este tipo de declaración.</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>'End Set' debe ir precedida de la instrucción 'Set' correspondiente.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>El modificador /embed se admite únicamente cuando se emite un archivo PDB portátil (/debug:portable o /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>La interfaz '{0}' es ambigua con otra interfaz implementada '{1}' debido a los parámetros 'In' y 'Out' de '{2}'.</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>La instrucción no puede aparecer dentro del cuerpo de una interfaz.</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>'{0}' no es un parámetro de método.</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>'Continue While' solo puede aparecer dentro de una instrucción 'While'.</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>Demasiados argumentos para el método de extensión '{0}' definido en '{1}'.</value>
@@ -3955,7 +3973,7 @@
     <value>El método no puede tener los parámetros ParamArray y Optional.</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>Un método de una estructura no se puede declarar como 'Protected' o 'Protected Friend'.</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>Se presupone que la variable de rango es de tipo Object porque su tipo no se puede inferir. Use una cláusula 'As' para especificar otro tipo.</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>No se puede especificar 'MustInherit' para el tipo parcial '{0}' porque no se puede combinar con 'NotInheritable' especificado para uno de sus tipos parciales.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>En un evento de Windows Runtime, el tipo de parámetro de método 'RemoveHandler' debe ser 'EventRegistrationToken'</value>
@@ -4325,162 +4346,164 @@
     <value>Se esperaba 'Is'.</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Opciones del compilador de Visual Basic
+    <value>                  Visual Basic Compiler Options
 
-                                  - ARCHIVO DE SALIDA -
-/out:&lt;archivo&gt;                       Especificar nombre del archivo de salida.
-/target:exe                       Crear una aplicación de consola (predeterminado). 
-                                  (Forma corta: /t)
-/target:winexe                    Crear una aplicación de Windows.
-/target:library                   Crear un ensamblado de biblioteca.
-/target:module                    Crear un módulo que se pueda agregar a un 
-                                  ensamblado.
-/target:appcontainerexe           Crear una aplicación de Windows que se ejecute en 
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
+                                  assembly.
+/target:appcontainerexe           Create a Windows application that runs in 
                                   AppContainer.
-/target:winmdobj                  Crear un archivo intermedio de metadatos de Windows.
-/doc[+|-]                         Genera un archivo de documentación XML.
-/doc:&lt;archivo&gt;                       Genera un archivo de documentación XML en &lt;archivo&gt;.
-/refout:&lt;archivo&gt;                    Salida del ensamblado de referencia para generar
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - ARCHIVOS DE ENTRADA -
-/addmodule:&lt;lista_archivos &gt;            Hacer referencia a metadatos desde los módulos especificados
-/link:&lt;lista_archivos&gt;                 Insertar metadatos desde el ensamblado de interoperabilidad 
-                                  especificado. (Forma corta: /l)
-/recurse:&lt; carácter comodín &gt;               Incluir todos los archivos en el directorio y los
-                                  subdirectorios actuales según las
-                                  especificaciones del carácter comodín.
-/reference:&lt;lista_archivos&gt;            Hacer referencia a los metadatos desde el ensamblado 
-                                  especificado. (Forma corta: /r)
-/analyzer:&lt;lista_archivos &gt;             Ejecutar analizadores desde este ensamblado
-                                  (forma corta: /a)
-/additionalfile:&lt;lista archivos&gt;       Archivos adicionales que no afectan directamente a la
-                                  generación de código, pero que los analizadores pueden usar para producir
-                                  errores o advertencias.
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - RECURSOS -
-/linkresource:&lt;info recurso&gt;           Vincula el archivo especificado como un recurso 
-                                  de ensamblado externo.
-                                  resinfo:&lt;archivo&gt;[,&lt;nombre&gt;[,public|private]] 
-                                  (Forma corta: /linkres)
-/nowin32manifest                  El manifiesto predeterminado no debe estar insertado
-                                  en la sección del manifiesto del PE de salida.
-/resource:&lt;info recurso&gt;               Agrega el archivo especificado como un recurso 
-                                  de ensamblado externo.
-                                  resinfo:&lt;archivo&gt;[,&lt;nombre&gt;[,public|private]] 
-                                  (Forma corta: /res)
-/win32icon:&lt;archivo&gt;                 Especifica un archivo de icono Win32 (.ico) para los 
-                                  recursos Win32 predeterminados.
-/win32manifest:&lt;archivo&gt;             El archivo proporcionado está insertado en la sección
-                                  del manifiesto del PE de salida.
-/win32resource:&lt;archivo&gt;             Especifica un archivo de recurso Win32 (.res).
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - GENERACIÓN DE CÓDIGO -
-/optimize[+|-]                    Habilitar optimizaciones.
-/removeintchecks[+|-]             Quitar comprobaciones de enteros. Desactivado de forma predeterminada.
-/debug[+|-]                       Emitir información de depuración.
-/debug:full                      Emitir información de depuración completa (valor predeterminado).
-/debug:pdbonly                    Emitir información de depuración completa.
-/debug:portable                   Emitir información de depuración multiplataforma.
-/debug:embedded                   Emitir información de depuración multiplataforma en el
-                                  archivo .dll o .exe de destino.
-/deterministic                    Producir un ensamblado determinista
-                                  (que incluya el GUID de la versión y la marca de tiempo del módulo)
-/refonly                          Producir un ensamblado de referencia en lugar de la salida principal
-/instrument:TestCoverage          Producir un ensamblado instrumentado para recopilar
-                                  la información de cobertura
-/sourcelink:&lt;archivo&gt;                Información del vínculo de origen para insertar en el PDB.
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - ERRORES Y ADVERTENCIAS -
-/nowarn                           Deshabilitar todas las advertencias.
-/nowarn:&lt;lista_números &gt;             Deshabilitar una lista de advertencias individuales.
-/warnaserror[+|-]                 Tratar todas las advertencias como errores.
-/warnaserror[+|-]:&lt;lista_números&gt;   Tratar una lista de advertencias como errores.
-/ruleset:&lt;file&gt;                   Especificar un archivo de conjunto de reglas que deshabilite diagnósticos
-                                  específicos.
-/errorlog:&lt;archivo&gt;                  Especificar un archivo para registrar todos los diagnósticos del
-                                  compilador y el analizador.
-/reportanalyzer                   Notificar información adicional del analizador, como
-                                  el tiempo de ejecución.
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-                                  - LENGUAJE -
-/define:&lt;lista _símbolos&gt;             Declarar símbolos de compilación condicional
-                                  global. symbol_list:name=value,... 
-                                  (Forma corta: /d)
-/imports:&lt;lista_importaciones&gt;            Declarar importaciones globales para los espacios de nombres de
-                                  los archivos de metadatos a los que se hace referencia. 
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
                                   import_list:namespace,...
-/langversion:&lt;número&gt;             Especificar versión del lenguaje: 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest
-/optionexplicit[+|-]              Requerir declaración explícita de variables.
-/optioninfer[+|-]                 Permitir inferencia de tipos de variables.
-/rootnamespace:&lt;cadena&gt;           Especifica espacio de nombres raíz para todas las declaraciones 
-                                  de tipos.
-/optionstrict[+|-]                Exigir semántica de lenguaje estricta.
-/optionstrict:custom              Advertir cuando no se respete la semántica del lenguaje
-                                  estricta.
-/optioncompare:binary             Especificar comparaciones de cadenas de estilo binario.
-                                  Es el valor predeterminado.
-/optioncompare:text               Especificar comparaciones de cadenas de estilo de texto.
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - VARIOS -
-/help                             Muestra este mensaje de uso. (Forma corta: /?)
-/noconfig                         No incluir automáticamente el archivo VBC.RSP.
-/nologo                           No mostrar pancarta de copyright del compilador.
-/quiet                            Modo de salida silencioso.
-/verbose                          Mostrar mensajes detallados.
-/parallel[+|-]                    Compilación simultánea. 
-/version                          Mostrar el número de versión del compilador y salir.
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - AVANZADO -
-/baseaddress:&lt;número&gt;             Dirección base de una biblioteca o módulo
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
                                   (hex).
-/checksumalgorithm:&lt;algoritmo&gt;          Especificar el algoritmo para calcular la suma de comprobación
-                                  del archivo de origen almacenado en PDB. Los valores admitidos son:
-                                  SHA1 (predeterminado) o SHA256.
-/codepage:&lt;número&gt;                Especifica la página de códigos que se va a usar al abrir
-                                  los archivos de origen.
-/delaysign[+|-]                   Retrasar la firma del ensamblado con solo la parte pública
-                                  de la clave de nombre seguro.
-/publicsign[+|-]                  Publicar firma del ensamblado con solo la parte pública
-                                  de la clave de nombre seguro.
-/errorreport:&lt;cadena&gt;             Especificar cómo tratar los errores internos del
-                                  compilador: avisar, enviar, ninguno o poner en cola
-                                  (predeterminado).
-/filealign:&lt;número&gt;               Especificar la alineación que se usa para las secciones del archivo de
-                                  salida.
-/highentropyva[+|-]               Habilitar ASLR de alta entropía.
-/keycontainer:&lt;cadena&gt;            Especificar un contenedor de clave de nombre seguro.
-/keyfile:&lt;archivo&gt;                   Especificar un archivo de clave de nombre seguro.
-/libpath:&lt;lista_rutas &gt;              Lista de directorios para buscar referencias de
-                                  metadatos. (Delimitada por punto y coma).
-/main:&lt;clase&gt;                     Especifica la clase o el módulo que contiene 
-                                  Sub Main. También puede ser una clase que
-                                  Herede de System.Windows.Forms.Form. 
-                                  (Forma corta: /m)
-/moduleassemblyname:&lt;cadena&gt;      Nombre del ensamblado del que será parte
-                                  este módulo.
-/netcf                            Destino de.NET Compact Framework.
-/nostdlib                         No hacer referencia a las bibliotecas estándar
-                                  (archivo system.dll y VBC.RSP).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
 /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                                  Especificar una asignación para los nombres de ruta de acceso de origen 
-                                  producidos por el compilador.
-/platform:&lt;cadena&gt;                Limitar en qué plataformas se puede ejecutar este código; 
-                                  Debe ser x86, x64, Itanium, arm,
-                                  AnyCPU32BitPreferred o anycpu (valor predeterminado).
-/preferreduilang                  Especificar el nombre del lenguaje de salida preferido.
-/sdkpath:&lt;ruta de acceso&gt;                   Ubicación del directorio del SDK de.NET Framework
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
                                   (mscorlib.dll).
-/subsystemversion:&lt;versión&gt;       Especificar la versión del subsistema del PE de salida. 
-                                  version:&lt;número&gt;[.&lt;número&gt;]
-/utf8output[+|-]                  Emitir salida del compilador en codificación de caracteres 
-                                  UTF8.
-@&lt;archivo&gt;                           Insertar la configuración de línea de comandos desde un archivo de texto
-/vbruntime[+|-|*]                 Compilar con o sin el entorno de ejecución predeterminado de
-                                  Visual Basic.
-/vbruntime:&lt;archivo&gt;                 Compilar con el entorno de ejecución alternativo de
-                                  Visual Basic en &lt;archivo&gt;.
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
+                                  version:&lt;number&gt;[.&lt;number&gt;]
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4493,7 +4516,7 @@
     <value>'{0}' no puede invalidar '{1}' porque difieren en las restricciones de parámetros de tipo.</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>Se esperaba un argumento con nombre.</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>La constante '{0}' no puede depender de su propio valor.</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.fr.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.fr.resx
@@ -447,7 +447,7 @@
     <value>La référence d'assembly '{0}' n'est pas valide et ne peut pas être résolue.</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>Vous pouvez spécifier uniquement une instance de type 'Public', 'Private', 'Protected', 'Friend' ou 'Protected Friend'.</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>L’expression lambda ne sera pas supprimée de ce gestionnaire d’événements</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>'{0}' porte le même nom qu'un autre membre utilisé pour le type '{1}' exposé dans un groupe 'My'. Renommez le type ou son espace de noms englobant.</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>'{0}' n'est pas un événement de '{1}'.</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>Impossible d'utiliser le type '{0}' dans ce contexte, car '{0}' est un paramètre de type 'Out'.</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>'{0}' et '{1}' ne peuvent pas se surcharger mutuellement, car seul l'un d'entre eux est déclaré 'Default'.</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>Impossible de déduire un type commun, car plusieurs types sont possibles. Type 'Object' pris par défaut.</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>Constante de chaîne attendue.</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>Les instructions 'ReDim' requièrent une liste entre parenthèses des nouvelles limites de chaque dimension du tableau.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>L'attribut '{0}' ne peut pas être appliqué à '{1}' de '{2}', car il n'est pas valide dans ce type de déclaration.</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>'End Set' doit être précédé d'un 'Set' correspondant.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Le commutateur /embed est uniquement pris en charge durant l'émission d'un fichier PDB portable (/debug:portable ou /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>La présence des paramètres 'In' et 'Out' dans '{2}' crée une ambiguïté entre l'interface '{0}' et une autre interface '{1}' implémentée.</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>L'instruction ne peut pas apparaître dans le corps d'une interface.</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>'{0}' n'est pas un paramètre de méthode.</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>'Continue While' ne peut apparaître que dans une instruction 'While'.</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>Arguments trop nombreux dans la méthode d'extension '{0}' définie dans '{1}'.</value>
@@ -3955,7 +3973,7 @@
     <value>La méthode ne peut pas comporter simultanément des paramètres ParamArray et Optional.</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>Une méthode dans une structure ne peut pas être déclarée 'Protected' ni 'Protected Friend'.</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>La variable de portée est considérée comme étant de type Object, car son type ne peut pas être déduit. Utilisez une clause 'As' pour indiquer un type différent.</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>'MustInherit' ne peut pas être spécifié pour le type partiel '{0}', car il ne peut pas être combiné avec 'NotInheritable' spécifié pour l'un de ses autres types partiels.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>Dans un événement Windows Runtime, le type du paramètre de méthode 'RemoveHandler' doit être 'EventRegistrationToken'</value>
@@ -4325,162 +4346,164 @@
     <value>'Is' attendu.</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Options du compilateur Visual Basic
+    <value>                  Visual Basic Compiler Options
 
-                                  - FICHIER DE SORTIE -
-/out:&lt;fichier&gt;                Spécifie le nom du fichier de sortie.
-/target:exe                       Créer une application console (par défaut). 
-                                  (Forme abrégée : /t)
-/target:winexe                    Créer une application Windows.
-/target:library                   Créer un assembly de bibliothèque.
-/target:module                    Créer un module qui peut être ajouté à un 
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
                                   assembly.
-/target:appcontainerexe           Créer une application Windows qui s'exécute dans 
+/target:appcontainerexe           Create a Windows application that runs in 
                                   AppContainer.
-/target:winmdobj                  Créer un fichier intermédiaire de métadonnées Windows
-/doc[+|-]                         Génère un fichier de documentation XML.
-/doc:&lt;fichier&gt;                Génère un fichier de documentation XML dans &lt;fichier&gt;.
-/refout:&lt;fichier&gt;                 Référencer la sortie d'assembly à générer
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - FICHIERS D'ENTRÉE -
-/addmodule:&lt;liste_fichiers&gt;   Référencer les métadonnées à partir des modules spécifiés
-/link:&lt;liste_fichiers&gt;        Incorporer les métadonnées à partir de 
-                                  l'assembly d'interopérabilité spécifié. (Forme abrégée : /l)
-/recurse:&lt;générique&gt;              Inclure tous les fichiers dans le répertoire 
-                                  et les sous-répertoires actifs en fonction des
-                                  spécifications des caractères génériques.
-/reference:&lt;liste_fichiers&gt;       Référencer les métadonnées à partir de 
-                                  l'assembly spécifié. (Forme abrégée : /r)
-/analyzer:&lt;liste_fichiers&gt;        Exécuter les analyseurs à partir de cet assembly
-                                  (Forme abrégée : /a)
-/additionalfile:&lt;liste_fich.&gt;     Fichiers supplémentaires qui n'affectent pas directement
-                                  la génération de code mais qui peuvent être utilisés par les analyseurs pour produire
-                                  des erreurs ou des avertissements.
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - RESSOURCES -
-/linkresource:&lt;resinfo&gt;           Lie le fichier spécifié sous forme de 
-                                  ressource d'assembly externe.
-                                  resinfo:&lt;fichier&gt;[,&lt;nom&gt;[,public|private]] 
-                                  (Forme abrégée : /linkres)
-/nowin32manifest                  Le manifeste par défaut ne doit pas être incorporé 
-                                  dans la section manifest du PE de sortie.
-/resource:&lt;resinfo&gt;               Ajoute le fichier spécifié en tant que 
-                                  ressource d'assembly incorporé.
-                                  resinfo:&lt;fichier&gt;[,&lt;nom&gt;[,public|private]] 
-                                  (Forme abrégée : /res)
-/win32icon:&lt;fichier&gt;              Spécifie un fichier icône Win32 (.ico) pour les 
-                                  ressources Win32 par défaut.
-/win32manifest:&lt;fichier&gt;          Le fichier fourni est incorporé dans la section manifest
-                                  du PE de sortie.
-/win32resource:&lt;fichier&gt;          Spécifie un fichier de ressources Win32 (.res).
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - GÉNÉRATION DE CODE -
-/optimize[+|-]                    Activer les optimisations.
-/removeintchecks[+|-]             Supprimer les contrôles sur les entiers. La valeur par défaut est off.
-/debug[+|-]                       Émettre des informations de débogage.
-/debug:full                       Émettre des informations de débogage complètes (par défaut).
-/debug:pdbonly                    Émettre des informations de débogage complètes.
-/debug:portable                   Émettre des informations de débogage multiplateformes.
-/debug:embedded                   Émettre des informations de débogage multiplateformes dans 
-                                  le fichier .dll ou .exe cible.
-/deterministic                    Produire un assembly déterministe
-                                  (en incluant le GUID et l'horodateur de la version du module)
-/refonly                          Produire un assembly de référence à la place de la sortie principale
-/instrument:TestCoverage          Produire un assembly instrumenté pour collecter
-                                  les informations de couverture
-/sourcelink:&lt;fichier&gt;             Informations du lien source à incorporer dans le fichier PDB.
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - ERREURS ET AVERTISSEMENTS -
-/nowarn                           Désactiver tous les avertissements.
-/nowarn:&lt;liste_numéros&gt;           Désactiver une liste d'avertissements individuels.
-/warnaserror[+|-]                 Traiter tous les avertissements comme des erreurs.
-/warnaserror[+|-]:&lt;liste_numéros&gt; Traiter une liste d'avertissements comme des erreurs.
-/ruleset:&lt;fichier&gt;                Spécifier un fichier ruleset qui désactive des
-                                  diagnostics spécifiques.
-/errorlog:&lt;fichier&gt;               Spécifier un fichier pour journaliser tous les diagnostics du compilateur
-                                  et de l'analyseur.
-/reportanalyzer                   Indiquer des informations supplémentaires sur l'analyseur, comme
-                                  la durée d'exécution.
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-                                  - LANGAGE -
-/define:&lt;liste_symboles&gt;          Déclarer des symboles de compilation 
-                                  conditionnelle globale. liste_symboles:name=value,... 
-                                  (Forme abrégée : /d)
-/imports:&lt;liste_importations&gt;     Déclarer des importations globales pour les espaces de noms dans 
-                                  les fichiers de métadonnées référencés. 
-                                  liste_importations:namespace,...
-/langversion:&lt;numéro&gt;             Spécifier la version du langage : 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest
-/optionexplicit[+|-]              Imposer une déclaration explicite des variables.
-/optioninfer[+|-]                 Autoriser l'inférence de type des variables.
-/rootnamespace:&lt;chaîne&gt;           Spécifie l'espace de noms racine pour toutes les 
-                                  déclarations de type.
-/optionstrict[+|-]                Appliquer une sémantique stricte du langage.
-/optionstrict:custom              Avertir quand la sémantique stricte du langage n'est pas
-                                  respectée.
-/optioncompare:binary             Spécifie des comparaisons de chaînes de style binaire.
-                                  Il s'agit de la valeur par défaut.
-/optioncompare:text               Spécifie des comparaisons de chaînes de style texte.
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
+                                  import_list:namespace,...
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - DIVERS -
-/help                             Afficher ce message d'utilisation. (Forme abrégée : /?)
-/noconfig                         Ne pas inclure automatiquement un fichier VBC.RSP.
-/nologo                           Ne pas afficher la bannière de copyright du compilateur.
-/quiet                            Mode de sortie silencieux.
-/verbose                          Afficher des messages documentés.
-/parallel[+|-]                    Build simultanée. 
-/version                          Afficher le numéro de version du compilateur et quitter le processus.
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - AVANCÉ -
-/baseaddress:&lt;numéro&gt;             Adresse de base d'une bibliothèque ou d'un module 
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
                                   (hex).
-/checksumalgorithm:&lt;alg&gt;          Spécifier l'algorithme de calcul de la somme de contrôle 
-                                  de fichier source stockée dans le fichier PDB. Valeurs prises en charge :
-                                  SHA1 (par défaut) ou SHA256.
-/codepage:&lt;numéro&gt;                Spécifie la page de codes à utiliser à l'ouverture 
-                                  des fichiers sources.
-/delaysign[+|-]                   Différer la signature de l'assembly en utilisant uniquement
-                                  la partie publique de la clé de nom fort.
-/publicsign[+|-]                  Signer publiquement l'assembly en utilisant uniquement
-                                  la partie publique de la clé de nom fort.
-/errorreport:&lt;chaîne&gt;             Spécifie comment gérer les erreurs internes du
-                                  compilateur ; doit avoir la valeur prompt, send, none ou queue
-                                  (par défaut).
-/filealign:&lt;numéro&gt;               Spécifier l'alignement utilisé pour les 
-                                  sections du fichier de sortie.
-/highentropyva[+|-]               Activer la randomisation du format d'espace d'adresse d'entropie élevée.
-/keycontainer:&lt;chaîne&gt;            Spécifie un conteneur de clé de nom fort.
-/keyfile:&lt;fichier&gt;                Spécifier un fichier de clé de nom fort.
-/libpath:&lt;liste_chemins&gt;          Liste de répertoires où rechercher des 
-                                  références de métadonnées. (Valeurs délimitées par des points-virgules.)
-/main:&lt;classe&gt;                    Spécifie la classe ou le module qui contient 
-                                  Sub Main. Il peut également s'agir d'une classe qui 
-                                  hérite de System.Windows.Forms.Form. 
-                                  (Forme abrégée : /m)
-/moduleassemblyname:&lt;chaîne&gt;      Nom de l'assembly dont ce module 
-                                  doit faire partie.
-/netcf                            Cibler le .NET Compact Framework.
-/nostdlib                         Ne pas référencer les bibliothèques standard 
-                                  (fichiers system.dll et VBC.RSP).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
 /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                                  Spécifier un mappage pour les noms de chemins sources sortis par
-                                  le compilateur.
-/platform:&lt;chaîne&gt;                Limiter les plateformes sur lesquelles ce code peut s'exécuter ; 
-                                  doit correspondre à x86, x64, Itanium, arm,
-                                  AnyCPU32BitPreferred ou anycpu (par défaut).
-/preferreduilang                  Spécifier le nom du langage de sortie préféré.
-/sdkpath:&lt;chemin&gt;                 Emplacement du répertoire du SDK .NET Framework
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
                                   (mscorlib.dll).
-/subsystemversion:&lt;version&gt;       Spécifier la version du sous-système du PE de sortie. 
-                                  version:&lt;numéro&gt;[.&lt;numéro&gt;]
-/utf8output[+|-]                  Émettre la sortie du compilateur au format 
-                                  d'encodage de caractères UTF8.
-@&lt;fichier&gt;                        Insérer les paramètres de ligne de commande à partir d'un fichier texte
-/vbruntime[+|-|*]                 Compiler avec/sans le
-                                  runtime Visual Basic par défaut.
-/vbruntime:&lt;fichier&gt;              Compiler avec le 
-                                  runtime Visual Basic de remplacement dans &lt;fichier&gt;.
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
+                                  version:&lt;number&gt;[.&lt;number&gt;]
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4493,7 +4516,7 @@
     <value>'{0}' ne peut pas se substituer à '{1}', car leurs contraintes de paramètre de type les différencient.</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>Argument nommé attendu.</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>La constante '{0}' ne peut pas dépendre de sa propre valeur.</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.it.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.it.resx
@@ -447,7 +447,7 @@
     <value>Il riferimento all'assembly '{0}' non è valido e non può essere risolto.</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>È possibile specificare solo un elemento tra 'Public', 'Private', 'Protected', 'Friend' e 'Protected Friend'.</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>L'espressione lambda non verrà rimossa da questo gestore eventi</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>'{0}' ha lo stesso nome di un membro usato per il tipo '{1}' esposto in un gruppo 'My'. Rinominare il tipo o lo spazio dei nomi che lo contiene.</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>'{0}' non è un evento di '{1}'.</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>Non è possibile usare il tipo '{0}' in questo contesto perché '{0}' è un parametro di tipo 'Out'.</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>'{0}' e '{1}' non possono essere in rapporto di overload perché solo uno è dichiarato come 'Default'.</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>Non è possibile dedurre un tipo comune perché sono possibili più tipi. Verrà usato 'Object'.</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>È prevista una costante di stringa.</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>Le istruzioni 'ReDim' richiedono un elenco tra parentesi dei nuovi limiti di ciascuna dimensione della matrice.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>Non è possibile applicare l'attributo '{0}' a '{1}' di '{2}'. L'attributo non è valido per questo tipo di dichiarazione.</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>'End Set' deve essere preceduto da un elemento 'Set' corrispondente.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>L'opzione /embed è supportata solo quando si crea il file PDB portatile (/debug:portable o /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>L'interfaccia '{0}' presenta ambiguità rispetto a un'altra interfaccia implementata '{1}' per la presenza dei parametri 'In' e 'Out' in '{2}'.</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>L'istruzione non può essere specificata all'interno di un corpo di interfaccia.</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>'{0}' non è un parametro di metodo.</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>'Continue While' può essere specificato solo all'interno di un'istruzione 'While'.</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>In '{1}' è stato definito un numero eccessivo di argomenti di tipo per il metodo di estensione '{0}'.</value>
@@ -3955,7 +3973,7 @@
     <value>Il metodo non può accettare entrambi i parametri ParamArray e Optional.</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>Il metodo in una struttura non può essere dichiarato come 'Protected' o 'Protected Friend'.</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>Si presuppone che la variabile di intervallo sia di tipo Object perché non è possibile dedurne il tipo. Usare una clausola 'As' per specificare un tipo diverso.</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>Non è possibile specificare 'MustInherit' per il tipo parziale '{0}' perché non può essere combinato con 'NotInheritable' specificato per uno degli altri tipi parziali.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>In un evento di Windows Runtime il tipo del parametro del metodo 'RemoveHandler' deve essere 'EventRegistrationToken'</value>
@@ -4325,160 +4346,164 @@
     <value>È previsto 'Is'.</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Opzioni del compilatore Visual Basic
+    <value>                  Visual Basic Compiler Options
 
-                                  - FILE DI OUTPUT -
-/out:&lt;file&gt;                       Consente di specificare il nome del file di output.
-/target:exe                       Consente di creare un'applicazione console (impostazione predefinita). 
-                                  Forma breve: /t
-/target:winexe                    Consente di creare un'applicazione Windows.
-/target:library                   Consente di creare un assembly di librerie.
-/target:module                    Consente di creare un modulo che può essere aggiunto a un
-                                   assembly.
-/target:appcontainerexe           Consente di creare un'applicazione Windows che viene eseguita in 
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
+                                  assembly.
+/target:appcontainerexe           Create a Windows application that runs in 
                                   AppContainer.
-/target:winmdobj                  Consente di creare un file intermedio di metadati di Windows
-/doc[+|-]                         Genera un file di documentazione XML.
-/doc:&lt;file&gt;                       Consente di generare un file di documentazione XML in &lt;file&gt;.
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - FILE DI INPUT -
-/addmodule:&lt;elenco_file&gt;            Consente di creare un riferimento ai metadati dai moduli specificati
-/link:&lt;elenco_file&gt;                 Incorpora i metadati dall'assembly di interoperabilità 
-                                  specificato. Forma breve: /l
-/recurse:&lt;caratterijolly&gt;               Include tutti i file presenti nella directory corrente 
-                                  e nelle relative sottodirectory in base
-                                  ai caratteri jolly specificati.
-/reference:&lt;elenco_file&gt;            Consente di creare un riferimento ai metadati dall'assembly 
-                                  specificato. Forma breve: /r
-/analyzer:&lt;elenco_file&gt;             Esegue gli analizzatori dall'assembly.
-                                  Forma breve: /a
-/additionalfile:&lt;elenco file&gt;       File aggiuntivi che non influiscono
-                                   direttamente sulla generazione del codice ma possono essere usati
-                                  dagli analizzatori per produrre errori o avvisi.
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - RISORSE -
-/linkresource:&lt;inforisorsa&gt;           Collega il file specificato come 
-                                  risorsa di assembly esterna.
-                                  resinfo:&lt;file&gt;[,&lt;nome&gt;[,public|private]] 
-                                  Forma breve: /linkres
-/nowin32manifest                  Il manifesto predefinito non deve essere incorporato nella 
-                                  sezione manifesto del file PE di output.
-/resource:&lt;inforisorsa&gt;               Aggiunge il file specificato come
-                                  risorsa di assembly incorporata.
-                                  resinfo:&lt;file&gt;[,&lt;nome&gt;[,public|private]] 
-                                  Forma breve: /res
-/win32icon:&lt;file&gt;                 Consente di specificare un file di icona Win32 (.ico) per le risorse 
-                                  Win32 predefinite.
-/win32manifest:&lt;file&gt;             Il file fornito è incorporato nella sezione manifesto 
-                                  del file PE di output.
-/win32resource:&lt;file&gt;             Consente di specificare un file di risorse Win32 (.res).
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - GENERAZIONE DEL CODICE -
-/optimize[+|-]                    Abilita le ottimizzazioni.
-/removeintchecks[+|-]             Rimuove il controllo dei numeri interi. Per impostazione predefinita, è disattivato.
-/debug[+|-]                       Crea le informazioni di debug.
-/debug:full                       Crea le informazioni di debug complete (impostazione predefinita).
-/debug:pdbonly                    Crea le informazioni di debug complete.
-/debug:portable                   Crea le informazioni di debug multipiattaforma.
-/debug:embedded                   Crea le informazioni di debug multipiattaforma nel file 
-                                  DLL o EXE di destinazione.
-/deterministic                    Produce un assembly deterministico
-                                  (che include GUID e timestamp della versione del modulo)
-/instrument:TestCoverage          Produce un assembly instrumentato per raccogliere
-                                  informazioni sul code coverage
-/sourcelink:&lt;file&gt;                Informazioni sul collegamento di origine da incorporare nel PDB portatile.
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - ERRORI E AVVISI -
-/nowarn                           Disabilita tutti gli avvisi.
-/nowarn:&lt;elenco_numeri&gt;             Disabilita un elenco di avvisi singoli.
-/warnaserror[+|-]                 Considera tutti gli avvisi come errori.
-/warnaserror[+|-]:&lt;elenco_numeri&gt;   Considera un elenco di avvisi come errori.
-/ruleset:&lt;file&gt;                   Consente di specificare un file di set di regole che disabilita
-                                  diagnostica specifica.
-/errorlog:&lt;file&gt;                  Consente di specificare un file in cui registrare tutte le diagnostiche del
-                                  compilatore e dell'analizzatore.
-/reportanalyzer                   Restituisce informazioni aggiuntive dell'analizzatore, ad
-                                  esempio il tempo di esecuzione.
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-                                  - LINGUAGGIO -
-/define:&lt;elenco_simboli&gt;             Dichiara simboli di compilazione condizionale 
-                                  globale. elenco_simboli:nome=valore,... 
-                                  Forma breve: /d
-/imports:&lt;elenco_importazioni&gt;            Dichiara le importazioni globali per spazi dei nomi in 
-                                  file di metadati a cui viene fatto riferimento. 
-                                  elenco_importazioni:spazio dei nomi,...
-/langversion:&lt;numero&gt;             Consente di specificare la versione del linguaggio: 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest
-/optionexplicit[+|-]              Richiede la dichiarazione esplicita delle variabili.
-/optioninfer[+|-]                 Consente l'inferenza del tipo delle variabili.
-/rootnamespace:&lt;stringa&gt;           Specifica lo spazio dei nomi radice per tutte le dichiarazioni 
-                                  di tipo.
-/optionstrict[+|-]                Applica la semantica del linguaggio strict.
-/optionstrict:custom              Avvisa quando la semantica del linguaggio strict non 
-                                  viene rispettata.
-/optioncompare:binary             Specifica i confronti fra stringhe binarie.
-                                  Impostazione predefinita.
-/optioncompare:text               Specifica i confronti fra stringhe di testo.
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
+                                  import_list:namespace,...
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - VARIE -
-/help                             Visualizza questo messaggio relativo alla sintassi. Forma breve: /?
-/noconfig                         Non include automaticamente il file VBC.RSP.
-/nologo                           Non visualizza le informazioni sul copyright del compilatore.
-/quiet                            Modalità di output non interattiva.
-/verbose                          Visualizza messaggi dettagliati.
-/parallel[+|-]                Compilazione simultanea. 
-/version                          Visualizza il numero di versione del compilatore ed esce.
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - AVANZATE -
-/baseaddress:&lt;numero&gt;             Indirizzo di base di una libreria o di un modulo 
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
                                   (hex).
-/checksumalgorithm:&lt;alg&gt;          Specifica l'algoritmo per calcolare il checksum 
-                                  del file di origine archiviato nel PDB. I valori supportati sono:
-                                  SHA1 (predefinito) o SHA256.
-/codepage:&lt;numero&gt;                Specifica la tabella codici da usare all'apertura dei file 
-                                  di origine.
-/delaysign[+|-]               Ritarda la firma dell'assembly usando solo la parte pubblica della 
-                                chiave con nome sicuro.
-/publicsign[+|-]              Firma pubblicamente l'assembly usando solo la parte pubblica
-                               della chiave con nome sicuro.
-/errorreport:&lt;stringa&gt;             Consente di specificare come gestire gli errori interni del compilatore. 
-                                  I valori devono essere prompt, send, none o queue
-                                  (impostazione predefinita).
-/filealign:&lt;numero&gt;               Consente di specificare l'allineamento usato per le sezioni del file di 
-                                  output.
-/highentropyva[+|-]           Abilita ASLR a entropia elevata.
-/keycontainer:&lt;stringa&gt;            Consente di specificare un contenitore di chiavi con nome sicuro.
-/keyfile:&lt;file&gt;                   Consente di specificare un file di chiave con nome sicuro.
-/libpath:&lt;elenco_percorsi&gt;              Elenco di directory delimitate da punti e virgola in cui cercare 
-                                   riferimenti ai metadati.
-/main:&lt;classe&gt;                      Consente di specificare la classe o il modulo che contiene 
-                                  Sub Main. Può essere anche una classe che 
-                                  eredita da System.Windows.Forms.Form.
-                                  Forma breve: /m
-/moduleassemblyname:&lt;stringa&gt;      Nome dell'assembly di cui farà parte questo 
-                                  modulo.
-/netcf                            Destinato a .NET Compact Framework.
-/nostdlib                         Omette i riferimenti alle librerie standard 
-                                  (system.dll e VBC.RSP file).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
 /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                                  Consente di specificare un mapping per i nomi di percorso di origine
-                                  visualizzati dal compilatore.
-/platform:&lt;stringa&gt;                Limita le piattaforme in cui è possibile eseguire questo codice. 
-                                  Il valore deve essere x86, x64, Itanium, arm,
-                                  AnyCPU32BitPreferred o anycpu (impostazione predefinita).
-/preferreduilang                  Consente di specificare il nome del linguaggio di output preferito.
-/sdkpath:&lt;percorso&gt;                   Percorso della directory di .NET Framework SDK 
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
                                   (mscorlib.dll).
-/subsystemversion:&lt;versione&gt;       Consente di specificare la versione del sottosistema del file PE di output. 
-                                  version:&lt;numero&gt;[.&lt;numero&gt;]
-/utf8output[+|-]                  Crea l'output del compilatore con codifica dei caratteri 
-                                  UTF8.
-@&lt;file&gt;                           Inserisce le impostazioni della riga di comando da un file di testo
-/vbruntime[+|-|*]                 Compila con/senza il runtime di Visual Basic 
-                                  predefinito.
-/vbruntime:&lt;file&gt;                 Compila con il runtime di Visual Basic alternativo 
-                                  in &lt;file&gt;.
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
+                                  version:&lt;number&gt;[.&lt;number&gt;]
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4491,7 +4516,7 @@
     <value>'{0}' non può eseguire l'override di '{1}' perché si differenziano per i vincoli del parametro di tipo.</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>È previsto l'argomento denominato.</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>La costante '{0}' non può dipendere dal proprio valore.</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.ja.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.ja.resx
@@ -447,7 +447,7 @@
     <value>アセンブリ参照 '{0}' は無効なため、解決できません。</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>'Public'、'Private'、'Protected'、'Friend'、または 'Protected Friend' は、いずれか 1 つしか指定できません。</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>ラムダ式はこのイベント ハンドラーから削除されません</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>'{0}' は 'My' グループ内で公開されている型 '{1}' に使用されるメンバーと同じ名前です。型またはそれを囲む名前空間の名前を変更してください。</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>'{0}' は '{1}' のイベントではありません。</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>'{0}' は 'Out' 型パラメーターであるため、このコンテキストでは型 '{0}' を使用できません。</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>'{0}' と '{1}' では、一方のみが 'Default' に宣言されているため、お互いをオーバーロードすることはできません。</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>複数の型が考えられるため、共通型を推論できません。'Object' と見なされます。</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>文字列定数を指定してください。</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>'ReDim' ステートメントには、配列の各次元の新しい境界の一覧をかっこで囲んだものが必要です。</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>属性 '{0}' を '{2}' の '{1}' に適用できません。この属性はこの種類の宣言では有効ではありません。</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>'End Set' の前には、対応する 'Set' を指定しなければなりません。</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>/embed スイッチは、ポータブル PDB の生成時にのみサポートされます (/debug:portable または /debug:embedded)。</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>インターフェイス '{0}' は、'{2}' の 'In' および 'Out' パラメーターが原因で、実装されている別のインターフェイス '{1}' に対してあいまいです。</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>ステートメントをインターフェイス本体内部に記述することはできません。</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>'{0}' はメソッド パラメーターではありません。</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>'Continue While' は、'While' ステートメント内でのみ使用できます。</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>'{1}' で定義された拡張メソッド '{0}' の引数が多すぎます。</value>
@@ -3955,7 +3973,7 @@
     <value>メソッドに ParamArray と省略可能なパラメーターの両方を指定することはできません。</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>構造体のメソッドを 'Protected' または 'Protected Friend' として宣言することはできません。</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>型を推論できないため、範囲変数は Object 型と見なされます。'As' 句を使って異なる型を指定してください。</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>'MustInherit' は、その他の partial 型の 1 つに指定された 'NotInheritable' と組み合わせて使用できないので、partial 型 '{0}' に指定できません。</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>Windows ランタイム イベントでは、'RemoveHandler' メソッド パラメーターの型を 'EventRegistrationToken' にする必要があります</value>
@@ -4325,162 +4346,164 @@
     <value>'Is' が必要です。</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Visual Basic コンパイラのオプション
+    <value>                  Visual Basic Compiler Options
 
-                                  - 出力ファイル -
-/out:&lt;file&gt;                       出力ファイル名を指定します。
-/target:exe                       コンソール アプリケーションを作成します (既定)。 
-                                  (短い形式: /t)
-/target:winexe                    Windows アプリケーションを作成します。
-/target:library                   ライブラリ アセンブリを作成します。
-/target:module                    アセンブリに追加できるモジュールを作成 
-                                  します。
-/target:appcontainerexe           AppContainer で実行される Windows アプリケーションを 
-                                  作成します。
-/target:winmdobj                  Windows メタデータ中間ファイルを作成します
-/doc[+|-]                         XML ドキュメント ファイルを生成します。
-/doc:&lt;file&gt;                       XML ドキュメント ファイルを &lt;file&gt; に生成します。
-/refout:&lt;file&gt;                    生成する参照アセンブリ出力
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
+                                  assembly.
+/target:appcontainerexe           Create a Windows application that runs in 
+                                  AppContainer.
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - 入力ファイル -
-/addmodule:&lt;file_list&gt;            指定されたモジュールからメタデータを参照します
-/link:&lt;file_list&gt;                 指定された相互運用アセンブリから 
-                                  メタデータを埋め込みます。 (短い形式: /l)
-/recurse:&lt;wildcard&gt;               ワイルドカードの指定に従い、
-                                  現在のディレクトリとサブディレクトリ内の
-                                  すべてのファイルをインクルードします。
-/reference:&lt;file_list&gt;            指定されたアセンブリから 
-                                  メタデータを参照します。 (短い形式: /r)
-/analyzer:&lt;file_list&gt;             このアセンブリからアナライザーを実行します
-                                  (短い形式: /a)
-/additionalfile:&lt;file list&gt;       コード生成には直接影響しないものの、
-                                  アナライザーがエラーまたは警告を
-                                  生成するために必要な追加ファイル。
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - リソース -
-/linkresource:&lt;resinfo&gt;           指定されたファイルを外部のアセンブリ リソースとして 
-                                  リンクします。
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
                                   resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
-                                  (短い形式: /linkres)
-/nowin32manifest                  出力 PE のマ二フェスト セクションに既定の 
-                                  マ二フェストを埋め込んではいけません。
-/resource:&lt;resinfo&gt;               指定されたファイルを 
-                                  埋め込みアセンブリ リソースとして追加します。
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
                                   resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
-                                  (短い形式: /res)
-/win32icon:&lt;file&gt;                 Win32 アイコン ファイル (.ico) を 
-                                  既定の Win32 リソースに使用します。
-/win32manifest:&lt;file&gt;             指定されたファイルは出力 PE の
-                                  マニフェスト セクションに埋め込まれています。
-/win32resource:&lt;file&gt;             Win32 リソース ファイル (.res) を指定します。
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - コード生成 -
-/optimize[+|-]                    最適化を有効にします。
-/removeintchecks[+|-]             整数のチェックを削除します。既定値は Off です。
-/debug[+|-]                       デバッグ情報を生成します。
-/debug:full                       完全なデバッグ情報を生成します (既定値)。
-/debug:pdbonly                    PDB ファイルのみを生成します。
-/debug:portable                   クロスプラットフォーム デバッグ情報を生成します。
-/debug:embedded                   クロスプラットフォーム デバッグ情報を
-                                  ターゲット .dll または .exe 内に生成します。
-/deterministic                    決定論的アセンブリを作成します
-                                  (モジュール バージョン GUID やタイムスタンプなど)
-/refonly                          メイン出力の代わりに参照アセンブリを生成します。
-/instrument:TestCoverage          カバレッジ情報を収集するようにインストルメント
-                                  されたアセンブリを生成します。
-/sourcelink:&lt;file&gt;                ポータブル PDB に埋め込むソース リンク情報。
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - エラーと警告 -
-/nowarn                           すべての警告を無効にします。
-/nowarn:&lt;number_list&gt;             個々の警告リストを無効にします。
-/warnaserror[+|-]                 すべての警告をエラーとして扱います。
-/warnaserror[+|-]:&lt;number_list&gt;   警告リストをエラーとして扱います。
-/ruleset:&lt;file&gt;                   特定の診断を無効にするルールセット ファイルを
-                                  指定します。
-/errorlog:&lt;file&gt;                  すべてのコンパイラおよびアナライザーの診断を
-                                  ログに記録するためのファイルを指定します。
-/reportanalyzer                   追加のアナライザー情報を報告します
-                                  (実行時間など)。
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-                                  - 言語 -
-/define:&lt;symbol_list&gt;             条件付きコンパイル シンボルをグローバルに宣言 
-                                  します。symbol_list:name=value,... 
-                                  (短い形式: /d)
-/imports:&lt;import_list&gt;            参照されたメタデータ ファイルの 
-                                  名前空間に対して Imports をグローバルに宣言します。 
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
                                   import_list:namespace,...
-/langversion:&lt;number&gt;             言語バージョンを指定します: 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest
-/optionexplicit[+|-]              変数の明示的な宣言を必須にします。
-/optioninfer[+|-]                 変数の型の推定を許可します。
-/rootnamespace:&lt;string&gt;           すべての型宣言に対して 
-                                  ルート名前空間を指定します。
-/optionstrict[+|-]                厳密な言語セマンティクスを適用します。
-/optionstrict:custom              厳密な言語セマンティクスが 
-                                  守られていないときに警告します。
-/optioncompare:binary             バイナリ スタイルの文字列比較を指定します。 
-                                  これは既定値です。
-/optioncompare:text               テキスト スタイルの文字列比較を指定します。
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - その他 -
-/help                             使用法に関するメッセージを表示します。 (短い形式: /?)
-/noconfig                         VBC.RSP ファイルを自動的にはインクルードしません。
-/nologo                           コンパイラの著作権情報を表示しません。
-/quiet                            非表示出力モードです。
-/verbose                          詳細メッセージを表示します。
-/parallel[+|-]                    ビルドを並列処理します。 
-/version                          コンパイラのバージョン番号を出力して終了します。
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - 詳細 -
-/baseaddress:&lt;number&gt;             ライブラリまたはモジュールのベース アドレス 
-                                  (16 進)。
-/checksumalgorithm:&lt;alg&gt;          PDB に格納されているソース ファイルのチェックサム 
-                                  を計算するアルゴリズムを指定します。サポートされる値:
-                                  SHA1 (既定) や SHA256。
-/codepage:&lt;number&gt;                ソース ファイルを開くときに使用するコード ページを 
-                                  指定します。
-/delaysign[+|-]                   アセンブリの遅延署名には厳密な名前キーのうち
-                                  公開された部分のみを使用します。
-/publicsign[+|-]                  厳密な名前のキーの公開部分のみを使ってアセンブリ
-                                  を公開署名します。
-/errorreport:&lt;string&gt;             内部コンパイラ エラーの処理方法を指定
-                                  します。prompt、send、none、queue 
-                                  (既定) のいずれかでなければなりません。
-/filealign:&lt;number&gt;               出力ファイル セクションで使う配置 
-                                  を指定します。
-/highentropyva[+|-]               高エントロピ ASLR を有効化します。
-/keycontainer:&lt;string&gt;            厳密な名前キーのコンテナーを指定します。
-/keyfile:&lt;file&gt;                   厳密な名前キーのファイルを指定します。
-/libpath:&lt;path_list&gt;              メタデータ参照を検索する 
-                                  ディレクトリの (セミコロン区切りの) リスト。
-/main:&lt;class&gt;                     Sub Main を含むクラスまたはモジュール 
-                                  を指定します。System.Windows.Forms.Form から継承
-                                  されるクラスまたはモジュールにすることもできます。
-                                  (短い形式: /m)
-/moduleassemblyname:&lt;string&gt;      このモジュールが一部となる 
-                                  アセンブリ名です。
-/netcf                            .NET Compact Framework をターゲットにします。
-/nostdlib                         標準ライブラリ 
-                                  (system.dll と VBC.RSP ファイル) を参照しません。
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
+                                  (hex).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
 /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                                  コンパイラが出力するソース パス名のマッピングを
-                                  指定します。
-/platform:&lt;string&gt;                このコードを実行できるプラットフォームは 
-                                  x86、x64、Itanium、arm、
-                                  AnyCPU32BitPreferred、anycpu (既定) でなければなりません。
-/preferreduilang                  出力用の言語名を指定します。
-/sdkpath:&lt;path&gt;                   .NET Framework SDK ディレクトリ (mscorlib.dll) 
-                                  の場所。
-/subsystemversion:&lt;version&gt;       出力 PE のサブシステム バージョンを指定します。 
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
+                                  (mscorlib.dll).
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
                                   version:&lt;number&gt;[.&lt;number&gt;]
-/utf8output[+|-]                  コンパイラ出力を UTF-8 文字エンコード 
-                                  で作成します。
-@&lt;file&gt;                           コマンドライン設定をテキスト ファイルから挿入します
-/vbruntime[+|-|*]                 既定の Visual Basic ランタイムを使用して/使用せずに
-                                  コンパイルします。
-/vbruntime:&lt;file&gt;                 &lt;file&gt; の別の Visual Basic ランタイムを使用して  
-                                  コンパイルします。
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4493,7 +4516,7 @@
     <value>型パラメーターの制約が異なるため、'{0}' で '{1}' をオーバーライドすることはできません。</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>名前付き引数が必要です。</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>定数 '{0}' が、それ自体の値に依存することはできません。</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.ko.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.ko.resx
@@ -447,7 +447,7 @@
     <value>'{0}' 어셈블리 참조가 잘못되어 확인할 수 없습니다.</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>'Public', 'Private', 'Protected', 'Friend' 또는 'Protected Friend' 중 하나만 지정할 수 있습니다.</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>이벤트 처리기에서 람다 식이 제거되지 않음</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>'{0}'의 이름이 '{1}' 형식을 'My' 그룹에 노출하는 데 사용한 멤버와 같습니다. 형식 또는 형식의 바깥쪽 네임스페이스의 이름을 바꾸세요.</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>'{0}'은(는) '{1}'의 이벤트가 아닙니다.</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>'{0}'이(가) 'Out' 형식 매개 변수이므로 '{0}' 형식을 이 컨텍스트에서 사용할 수 없습니다.</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>'{0}'과(와) '{1}' 중 하나만 'Default'로 선언되었으므로 서로 오버로드할 수 없습니다.</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>두 개 이상의 형식이 가능하므로 공용 형식을 유추할 수 없습니다. 'Object'로 간주합니다.</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>문자열 상수가 필요합니다.</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>'ReDim' 문에는 배열의 각 차원에 대한 새 범위 목록이 괄호 안에 있어야 합니다.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>이 선언 형식에서는 '{0}' 특성이 유효하지 않으므로 '{2}'의 '{1}'에 적용할 수 없습니다.</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>'End Set'은 짝이 되는 'Set' 뒤에 와야 합니다.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>/embed 스위치는 이식 가능한 PDB를 내보낼 때만 지원됩니다(/debug:portable 또는 /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>'{2}'에 있는 'In' 및 'Out' 매개 변수로 인해 '{0}' 인터페이스가 구현된 다른 인터페이스 '{1}'에 대해 모호합니다.</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>인터페이스 본문 안에는 문을 사용할 수 없습니다.</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>'{0}'은(는) 메서드 매개 변수가 아닙니다.</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>'Continue While'은 'While' 문 내부에만 사용할 수 있습니다.</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>'{1}'에 정의된 확장 메서드 '{0}'의 인수가 너무 많습니다.</value>
@@ -3955,7 +3973,7 @@
     <value>메서드에는 ParamArray 매개 변수와 Optional 매개 변수를 함께 사용할 수 없습니다.</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>구조체의 메서드는 'Protected' 또는 'Protected Friend'로 선언할 수 없습니다.</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>형식을 유추할 수 없어 범위 변수가 Object 형식으로 간주됩니다. 'As' 절을 사용하여 다른 형식을 지정하세요.</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>'MustInherit'은 다른 부분 형식(Partial Type) 중 하나에 지정된 'NotInheritable'과 함께 사용할 수 없으므로 '{0}' 부분 형식에 지정할 수 없습니다.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>Windows 런타임 이벤트에서 'RemoveHandler' 메서드 매개 변수의 형식은 'EventRegistrationToken'이어야 합니다.</value>
@@ -4325,162 +4346,164 @@
     <value>'Is'가 필요합니다.</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Visual Basic 컴파일러 옵션
+    <value>                  Visual Basic Compiler Options
 
-                                  - 출력 파일 -
-/out:&lt;file&gt;                       출력 파일 이름을 지정합니다.
-/target:exe                       콘솔 응용 프로그램을 만듭니다(기본값). 
-                                  (약식: /t)
-/target:winexe                    Windows 응용 프로그램을 만듭니다.
-/target:library                   라이브러리 어셈블리를 만듭니다.
-/target:module                    어셈블리에 추가할 수 있는 모듈을 
-                                  만듭니다.
-/target:appcontainerexe           AppContainer에서 실행되는 Windows 응용 프로그램을 
-                                  만듭니다.
-/target:winmdobj                  Windows 메타데이터 중간 파일을 만듭니다.
-/doc[+|-]                         XML 문서 파일을 생성합니다.
-/doc:&lt;file&gt;                       XML 문서 파일을 &lt;file&gt;에 생성합니다.
-/refout:&lt;file&gt;                생성할 참조 어셈블리 출력
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
+                                  assembly.
+/target:appcontainerexe           Create a Windows application that runs in 
+                                  AppContainer.
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - 입력 파일 -
-/addmodule:&lt;file_list&gt;            지정된 모듈에서 메타데이터를 참조합니다.
-/link:&lt;file_list&gt;                 지정된 interop 어셈블리의 메타데이터를 
-                                  포함합니다. (약식: /l)
-/recurse:&lt;wildcard&gt;               와일드카드 지정에 따라 현재 디렉터리와 
-                                  하위 디렉터리에 있는 모든 파일을
-                                  포함합니다.
-/reference:&lt;file_list&gt;            지정한 어셈블리 파일에서 메타데이터를 
-                                  참조합니다. (약식: /r)
-/analyzer:&lt;file_list&gt;             이 어셈블리에서 분석기를 실행합니다.
-                                  (약식: /a)
-/additionalfile:&lt;file list&gt;       코드 생성에 직접적인 영향을 주지 않지만
-                                  오류 또는 경고 생성을 위해 분석기에서 사용될 수 있는
-                                  추가 파일입니다.
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - 리소스 -
-/linkresource:&lt;resinfo&gt;           지정된 파일을 외부 어셈블리 
-                                  리소스로 연결합니다.
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
                                   resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
-                                  (약식: /linkres)
-/nowin32manifest                  기본 매니페스트는 출력 PE의 매니페스트 섹션에 
-                                  포함되면 안 됩니다.
-/resource:&lt;resinfo&gt;               지정한 파일을 포함된 어셈블리 
-                                  리소스로 추가합니다.
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
                                   resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
-                                  (약식: /res)
-/win32icon:&lt;file&gt;                 기본 Win32 리소스에 사용되는 Win32 아이콘 파일(.ico)을 
-                                  지정합니다.
-/win32manifest:&lt;file&gt;             제공된 파일은 출력 PE의 매니페스트
-                                  섹션에 포함됩니다.
-/win32resource:&lt;file&gt;             Win32 리소스 파일(.res)을 지정합니다.
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - 코드 생성 -
-/optimize[+|-]                    최적화를 사용합니다.
-/removeintchecks[+|-]             정수 확인을 제거합니다. 기본값은 off입니다.
-/debug[+|-]                       디버깅 정보를 내보냅니다.
-/debug:full                       전체 디버깅 정보를 내보냅니다(기본값).
-/debug:pdbonly                    전체 디버깅 정보를 내보냅니다.
-/debug:portable                   크로스 플랫폼 디버깅 정보를 내보냅니다.
-/debug:embedded                   크로스 플랫폼 디버깅 정보를 대상 .dll 또는 .exe로 
-                                  내보냅니다.
-/deterministic                    결정적 어셈블리를 생성합니다.
-                                  (모듈 버전 GUID 및 타임스탬프 포함)
-/refonly                          주 출력 대신 참조 어셈블리 생성
-/instrument:TestCoverage          검사 정보를 수집하기 위해 계측한
-                                  어셈블리를 생성합니다.
-/sourcelink:&lt;file&gt;                PDB에 포함할 소스 링크 정보입니다.
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - 오류 및 경고 -
-/nowarn                           모든 경고를 사용하지 않습니다.
-/nowarn:&lt;number_list&gt;             개별 경고 목록을 사용하지 않습니다.
-/warnaserror[+|-]                 모든 경고를 오류로 처리합니다.
-/warnaserror[+|-]:&lt;number_list&gt;   경고 목록을 오류로 처리합니다.
-/ruleset:&lt;file&gt;                   특정 진단을 사용하지 않도록 하는 규칙 집합을
-                                  지정합니다.
-/errorlog:&lt;file&gt;                  모든 컴파일러 및 분석기 진단을 기록할 파일을
-                                  지정합니다.
-/reportanalyzer                   추가 분석기 정보(예: 실행 시간)를
-                                  보고합니다.
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-                                  - 언어 -
-/define:&lt;symbol_list&gt;             전역 조건부 컴파일 기호를 
-                                  선언합니다. symbol_list:name=value,... 
-                                  (약식: /d)
-/imports:&lt;import_list&gt;            참조된 메타데이터 파일에 네임스페이스의 
-                                  전역 가져오기를 선언합니다. 
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
                                   import_list:namespace,...
-/langversion:&lt;number&gt;             언어 버전 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest를 지정합니다.
-/optionexplicit[+|-]              변수의 명시적 선언을 요구합니다.
-/optioninfer[+|-]                 변수의 형식 유추를 허용합니다.
-/rootnamespace:&lt;string&gt;           모든 형식 선언의 루트 네임스페이스를 
-                                  지정합니다.
-/optionstrict[+|-]                엄격한 언어 의미 체계를 적용합니다.
-/optionstrict:custom              엄격한 언어 의미 체계가 사용되지 않을 때 
-                                  경고합니다.
-/optioncompare:binary             이진 스타일 문자열 비교를 지정합니다.
-                                  기본값입니다.
-/optioncompare:text               텍스트 스타일 문자열 비교를 지정합니다.
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - 기타 -
-/help                             사용법 메시지를 표시합니다. (약식: /?)
-/noconfig                         VBC.RSP 파일을 자동으로 포함하지 않습니다.
-/nologo                           컴파일러 저작권 배너를 표시하지 않습니다.
-/quiet                            자동 출력 모드입니다.
-/verbose                          자세한 메시지를 표시합니다.
-/parallel[+|-]                    동시 빌드입니다. 
-/version                          컴파일러 버전 번호를 표시하고 종료합니다. 
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - 고급 -
-/baseaddress:&lt;number&gt;             16진수로 지정된 라이브러리 또는 모듈의 기준 
-                                  주소입니다.
-/checksumalgorithm:&lt;alg&gt;          PDB에 저장된 소스 파일 체크섬을 계산하기 위한 
-                                  알고리즘을 지정합니다. 지원되는 값은
-                                  SHA1(기본값) 또는 SHA256입니다.
-/codepage:&lt;number&gt;                소스 파일을 열 때 사용할 코드 페이지를 
-                                  지정합니다.
-/delaysign[+|-]                   강력한 이름 키의 공개 부분만 사용하여
-                                  어셈블리 서명을 연기합니다.
-/publicsign[+|-]                  강력한 이름 키의 공개 부분만 사용하여
-                                  어셈블리에 공개 서명합니다.
-/errorreport:&lt;string&gt;             내부 컴파일러 오류를 처리하는 방법을
-                                  prompt, send, none 또는 queue(기본값)
-                                  중에서 선택합니다.
-/filealign:&lt;number&gt;               출력 파일 섹션에 사용되는 맞춤을 
-                                  지정합니다.
-/highentropyva[+|-]               높은 엔트로피 ASLR을 사용합니다.
-/keycontainer:&lt;string&gt;            강력한 이름의 키 컨테이너를 지정합니다.
-/keyfile:&lt;file&gt;                   강력한 이름의 키 파일을 지정합니다.
-/libpath:&lt;path_list&gt;              메타데이터 참조에 대해 검색할 디렉터리 
-                                  목록이며 세미콜론으로 구분됩니다.
-/main:&lt;class&gt;                     Sub Main을 포함하는 클래스 또는 모듈을 
-                                  지정합니다. System.Windows.Forms.Form에서 상속하는 
-                                  클래스를 사용할 수도 있습니다. 
-                                  (약식: /m)
-/moduleassemblyname:&lt;string&gt;      이 모듈이 속할 어셈블리의 
-                                  이름입니다.
-/netcf                            .NET Compact Framework를 대상으로 지정합니다.
-/nostdlib                         표준 라이브러리(system.dll 및 VBC.RSP 파일)를 
-                                  참조하지 않습니다.
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
+                                  (hex).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
 /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                                  컴파일러에서 소스 경로 이름 출력에 대한
-                                  매핑을 지정합니다.
-/platform:&lt;string&gt;                이 코드를 실행할 수 있는 플랫폼을 
-                                  x86, x64, Itanium, arm,
-                                  AnyCPU32BitPreferred 또는 anycpu(기본값)로 제한합니다.
-/preferreduilang                  기본 출력 언어 이름을 지정합니다.
-/sdkpath:&lt;path&gt;                   .NET Framework SDK 디렉터리의 
-                                  위치(mscorlib.dll)입니다.
-/subsystemversion:&lt;version&gt;       출력 PE의 하위 시스템 버전을 지정합니다. 
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
+                                  (mscorlib.dll).
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
                                   version:&lt;number&gt;[.&lt;number&gt;]
-/utf8output[+|-]                  UTF8 문자 인코딩으로 컴파일러 출력을 
-                                  내보냅니다.
-@&lt;file&gt;                           텍스트 파일에서 명령줄 설정을 삽입합니다.
-/vbruntime[+|-|*]                 기본 Visual Basic 런타임을 사용하거나 사용하지 않고
-                                  컴파일합니다.
-/vbruntime:&lt;file&gt;                 &lt;file&gt;에서 대체 Visual Basic 런타임을 사용하여 
-                                  컴파일합니다.
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4493,7 +4516,7 @@
     <value>형식 매개 변수 제약 조건이 서로 다르므로 '{0}'은(는) '{1}'을(를) 재정의할 수 없습니다.</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>명명된 인수가 필요합니다.</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>'{0}' 상수는 자신의 값에 종속될 수 없습니다.</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.pl.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.pl.resx
@@ -447,7 +447,7 @@
     <value>Odwołanie do zestawu „{0}” jest nieprawidłowe i nie można go rozpoznać.</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>Można określić tylko jeden z modyfikatorów: Public, Private, Protected, Friend lub Protected Friend.</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>Wyrażenie lambda nie zostanie usunięte z tej procedury obsługi zdarzeń</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>Element „{0}” ma taką samą nazwę jak element członkowski użyty dla typu „{1}” ujawniony w grupie „My”. Zmień nazwę typu lub obejmującej go przestrzeni nazw.</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>Element „{0}” nie jest zdarzeniem elementu „{1}”.</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>Typ „{0}” nie może zostać użyty w tym kontekście, ponieważ „{0}” jest parametrem typu „Out”.</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>Elementy „{0}” i „{1}” nie mogą przeciążać siebie nawzajem, ponieważ tylko jeden z nich jest zadeklarowany jako „Default”.</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>Nie można wywnioskować wspólnego typu, ponieważ jest możliwy więcej niż jeden typ; przyjęto „Object”.</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>Oczekiwano stałej w postaci ciągu.</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>Instrukcja ReDim wymaga ujętej w nawiasy listy nowych granic dla każdego wymiaru tablicy.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>Nie można zastosować atrybutu „{0}” do elementu „{1}” w „{2}”, ponieważ atrybut nie jest prawidłowy w tym typie deklaracji.</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>Instrukcja End Set musi być poprzedzona odpowiadającą jej instrukcją Set.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Przełącznik /embed jest obsługiwany tylko w przypadku emitowania przenośnego pliku PDB (/debug:portable lub /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>Interfejs „{0}” jest niejednoznaczny z innym zaimplementowanym interfejsem „{1}” ze względu na parametry „In” i „Out” w „{2}”.</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>Instrukcja nie może wystąpić w treści interfejsu.</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>Element „{0}” nie jest parametrem metody.</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>Element Continue While może się znajdować tylko w instrukcji While.</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>Za dużo argumentów dla metody rozszerzenia „{0}” zdefiniowanej w elemencie „{1}”.</value>
@@ -3955,7 +3973,7 @@
     <value>Metoda nie może mieć zarówno parametru ParamArray, jak i Optional.</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>Nie można zadeklarować metody w strukturze jako Protected lub Protected Friend.</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>Przyjęto, że zmienna zakresu będzie typu Object, ponieważ nie można wywnioskować jej typu. Użyj klauzuli „As”, aby określić inny typ.</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>Elementu „MustInherit” nie można określić dla typu częściowego „{0}”, ponieważ nie można go łączyć z elementem „NotInheritable” określonym dla jednego z jego innych typów częściowych.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>W zdarzeniu środowiska wykonawczego systemu Windows parametr metody „RemoveHandler” musi mieć wartość „EventRegistrationToken”</value>
@@ -4325,160 +4346,164 @@
     <value>Oczekiwano instrukcji „Is”.</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Opcje kompilatora Visual Basic
+    <value>                  Visual Basic Compiler Options
 
-                                  - PLIK WYJŚCIOWY -
-/out:&lt;plik&gt;                       Określa nazwę pliku wyjściowego.
-/target:exe                       Utwórz aplikację konsolową (domyślnie). 
-                                  (krótka wersja: /t)
-/target:winexe                    Utwórz aplikację systemu Windows.
-/target:library                   Utwórz zestaw biblioteki.
-/target:module                    Utwórz moduł, który można dodać do 
-                                  zestawu.
-/target:appcontainerexe           Utwórz aplikację systemu Windows uruchamianą w 
-                                  kontenerze aplikacji.
-/target:winmdobj                  Utwórz plik pośredni metadanych systemu Windows
-/doc[+|-]                         Generuje plik dokumentacji XML.
-/doc:&lt;plik&gt;                       Generuje plik dokumentacji XML w pliku &lt;plik&gt;./refout:&lt;file&gt;                    Dane wyjściowe zestawu odwołania do wygenerowania
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
+                                  assembly.
+/target:appcontainerexe           Create a Windows application that runs in 
+                                  AppContainer.
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - PLIKI WEJŚCIOWE -
-/addmodule:&lt;lista_plików&gt;         Odwołuj się do metadanych z określonych modułów
-/link:&lt;lista_plików&gt;              Osadź metadane z określonego 
-                                  zestawu międzyoperacyjnego. (krótka wersja: /l)
-/recurse:&lt;symbol wieloznaczny&gt;    Dołącz wszystkie pliki zawarte w bieżącym katalogu 
-                                  i jego podkatalogach zgodnie ze
-                                  specyfikacją określoną przy użyciu symboli wieloznacznych.
-/reference:&lt;lista_plików&gt;         Odwołuj się do metadanych z określonego 
-                                  zestawu. (krótka wersja: /r)
-/analyzer:&lt;lista_plików&gt;          Uruchom analizatory z tego zestawu
-                                  (krótka wersja: /a)
-/additionalfile:&lt;lista plików&gt;    Dodatkowe pliki, które nie mają bezpośredniego wpływu
-                                  na generowanie kodu, ale mogą być używane przez analizatory w celu tworzenia
-                                  komunikatów o błędach lub ostrzeżeń.
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - ZASOBY -
-/linkresource:&lt;informacje o zasobie&gt;           Łączy określony plik jako 
-                                  zasób zewnętrzny zestawu.
-                                  resinfo:&lt;plik&gt;[,&lt;nazwa&gt;[,public|private]] 
-                                  (krótka wersja: /linkres)
-/nowin32manifest                  Manifest domyślny nie powinien być osadzony 
-                                  w sekcji manifestu w wyjściowym środowisku PE.
-/resource:&lt;informacje o zasobie&gt; Dodaje określony plik jako osadzony 
-                                  zasób zestawu.
-                                  resinfo:&lt;plik&gt;[,&lt;nazwa&gt;[,public|private]] 
-                                  (krótka wersja: /res)
-/win32icon:&lt;plik&gt;                 Określa plik ikony środowiska Win32 (ico) dla 
-                                  domyślnych zasobów środowiska Win32.
-/win32manifest:&lt;plik&gt;             Podany plik zostanie osadzony w
-                                  sekcji manifestu wyjściowego środowiska PE.
-/win32resource:&lt;plik&gt;             Określa plik zasobów środowiska Win32 (res).
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - GENEROWANIE KODU -
-/optimize[+|-]                    Włącz optymalizacje.
-/removeintchecks[+|-]             Usuń kontrole liczb całkowitych. Domyślnie wyłączone.
-/debug[+|-]                       Emituj informacje o debugowaniu.
-/debug:full                       Emituj pełne informacje o debugowaniu (domyślnie).
-/debug:pdbonly                                       Emituj pełne informacje o emitowaniu.
-/debug:portable                   Emituj informacje o debugowaniu międzyplatformowym.
-/debug:embedded                                       Emituj informacje o debugowaniu międzyplatformowym do 
-                                  docelowego pliku DLL lub EXE.
-/deterministic                    Utwórz zestaw deterministyczny
-                                  (w tym sygnaturę czasową i identyfikator GUID wersji modułu)
-/refonly                          Utwórz zestaw odwołania zamiast głównych danych wyjściowych
-/instrument:TestCoverage          Utwórz zestaw instrumentowany w celu gromadzenia
-                               informacji o pokryciu
-/sourcelink:&lt;file&gt;                Informacje o linku źródłowym do wbudowania w pliku PDB.
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - BŁĘDY I OSTRZEŻENIA -
-/nowarn                           Wyłącz wszystkie ostrzeżenia.
-/nowarn:&lt;lista_numerów&gt;           Wyłącz listę poszczególnych ostrzeżeń.
-/warnaserror[+|-]                 Traktuj wszystkie ostrzeżenia jako błędy.
-/warnaserror[+|-]:&lt;lista_numerów&gt; Traktuj ostrzeżenia z listy jako błędy.
-/ruleset:&lt;plik&gt;                   Określ plik zestawu reguł, który wyłącza określone
-                                  opcje diagnostyczne.
-/errorlog:&lt;plik&gt;                  Określ plik, w którym mają zostać zarejestrowane dane diagnostyczne
-                                  wszystkich kompilatorów i analizatorów.
-/reportanalyzer                   Zgłoś dodatkowe informacje analizatora, takie jak
-                                  czas wykonywania.
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-                                  - JĘZYK -
-/define:&lt;lista_symboli&gt;           Zadeklaruj globalne symbole 
-                                  kompilacji warunkowej. symbol_list:nazwa=wartość,... 
-                                  (krótka wersja: /d)
-/imports:&lt;lista_importów&gt;         Zadeklaruj globalne importy dla przestrzeni nazw w 
-                                  przywoływanych plikach metadanych. 
-                                  import_list:przestrzeń_nazw,...
-/langversion:&lt;numer&gt;              Określ wersję języka: 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest
-/optionexplicit[+|-]              Wymagaj jawnej deklaracji zmiennych.
-/optioninfer[+|-]                 Zezwalaj na wnioskowanie o typie zmiennych.
-/rootnamespace:&lt;ciąg&gt;             Określa główną przestrzeń nazw dla wszystkich 
-                                  deklaracji typów.
-/optionstrict[+|-]                Wymuszaj ścisłą semantykę języka.
-/optionstrict:custom              Ostrzegaj, gdy ścisła semantyka języka nie jest
-                                  przestrzegana.
-/optioncompare:binary             Określa binarne porównywanie ciągów.
-                                  Jest ono domyślne.
-/optioncompare:text               Określa tekstowe porównywanie ciągów.
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
+                                  import_list:namespace,...
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - RÓŻNE -
-/help                             Wyświetl ten komunikat dotyczący użycia. (krótka wersja: /?)
-/noconfig                         Nie dołączaj automatycznie pliku VBC.RSP.
-/nologo                           Nie wyświetlaj transparentu kompilatora z informacjami o prawach autorskich.
-/quiet                            Cichy tryb wyjściowy.
-/verbose                          Wyświetl pełne komunikaty.
-/parallel[+|-]                    Współbieżna kompilacja.
-/version                          Wyświetl numer wersji kompilatora i wyjdź.
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - ZAAWANSOWANE -
-/baseaddress:&lt;numer&gt;              Podstawowy adres biblioteki lub modułu 
-                                  (szesnastkowy).
-/checksumalgorithm:&lt;algorytm&gt;     Określ algorytm obliczania sumy kontrolnej 
-                                  pliku źródłowego przechowywanej w pliku PDB. Obsługiwane wartości:
-                                  SHA1 (domyślnie) lub SHA256.
-/codepage:&lt;numer&gt;                 Określa stronę kodową do użycia podczas otwierania 
-                                  plików źródłowych.
-/delaysign[+|-]                   Podpisz z opóźnieniem zestaw, używając tylko części publicznej
-                                  klucza o silnej nazwie.
-/errorreport:&lt;ciąg&gt;               Określa, w jaki sposób obsługiwać wewnętrzne
-                                  błędy kompilatora: musi mieć wartość prompt, send, none lub queue
-                                  (wartość domyślna).
-/filealign:&lt;numer&gt;                Określ wyrównanie stosowane dla sekcji 
-                                  plików wyjściowych.
-/highentropyva[+|-]               Włącz losowe generowanie układu przestrzeni adresowej o wysokiej entropii.
-/keycontainer:&lt;ciąg&gt;              Określa kontener klucza o silnej nazwie.
-/keyfile:&lt;plik&gt;                   Określa plik klucza o silnej nazwie.
-/libpath:&lt;lista_ścieżek&gt;          Lista katalogów, w których mają zostać wyszukane 
-                                  odwołania do metadanych (lista wartości oddzielonych średnikami).
-/main:&lt;klasa&gt;                     Określa klasę lub moduł zawierające 
-                                  element Sub Main. Może to również być klasa 
-                                  dziedzicząca po elemencie System.Windows.Forms.Form. 
-                                  (krótka wersja: /m)
-/moduleassemblyname:&lt;ciąg&gt;        Nazwa zestawu, do którego będzie należeć 
-                                  ten moduł.
-/netcf                            Ustaw program .NET Compact Framework jako element docelowy.
-/nostdlib                         Nie odwołuj się do bibliotek standardowych 
-                                  (plików system.dll i VBC.RSP).
-
-/pathmap:&lt;K1&gt;=&lt;W1&gt;,&lt;K2&gt;=&lt;W2&gt;,...
-                                  Określ mapowanie nazw ścieżek źródłowych wyprowadzanych
-                                  przez kompilator.
-/platform:&lt;ciąg&gt;                  Ogranicz platformy, na jakich można uruchomić ten kod; 
-                                  dozwolone wartości: x86, x64, Itanium, arm,
-                                  AnyCPU32BitPreferred lub anycpu (wartość domyślna).
-/preferreduilang                  Określ nazwę preferowanego języka wyjściowego.
-/sdkpath:&lt;ścieżka&gt;                Lokalizacja katalogu zestawu .NET Framework SDK
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
+                                  (hex).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
+/pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
                                   (mscorlib.dll).
-/subsystemversion:&lt;wersja&gt;        Określ wersję podsystemu wyjściowego środowiska PE. 
-                                  version:&lt;numer&gt;[.&lt;numer&gt;]
-/utf8output[+|-]                  Emituj dane wyjściowe kompilatora przy użyciu 
-                                  kodowania znaków UTF8.
-@&lt;plik&gt;                           Wstaw ustawienia wiersza polecenia z pliku tekstowego
-/vbruntime[+|-|*]                 Wykonaj kompilację przy użyciu/bez użycia domyślnego
-                                  środowiska uruchomieniowego języka Visual Basic.
-/vbruntime:&lt;plik&gt;                 Wykonaj kompilację przy użyciu alternatywnego 
-                                  środowiska uruchomieniowego języka Visual Basic w pliku &lt;plik&gt;.
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
+                                  version:&lt;number&gt;[.&lt;number&gt;]
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4491,7 +4516,7 @@
     <value>Element „{0}” nie może przesłonić elementu „{1}”, ponieważ elementy różnią się ograniczeniami parametrów typu.</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>Oczekiwano nazwanego argumentu.</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>Stała „{0}” nie może zależeć od własnej wartości.</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.pt-BR.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.pt-BR.resx
@@ -447,7 +447,7 @@
     <value>Referência de assembly "{0}" é inválida e não pode ser resolvida.</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>Somente um de 'Public', 'Private', 'Protected', 'Friend', ou 'Protected Friend' pode ser especificado.</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>A expressão lambda não será removida deste manipulador de eventos</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>"{0}" tem o mesmo nome de um membro usado para o tipo "{1}" exposto em um grupo "My". Renomeie o tipo ou seu namespace delimitador.</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>"{0}" não é um evento de "{1}".</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>Tipo "{0}" não pode ser usado neste contexto porque "{0}" é um parâmetro de tipo "Out".</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>"{0}" e "{1}" não podem sobrecarregar um ao outro porque somente um está declarado como "Default".</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>Não é possível deduzir um tipo comum porque mais de um tipo é possível; 'Object' presumido.</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>Constante de cadeia de caracteres esperada.</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>Instruções 'ReDim' requerem uma lista delimitada por parênteses dos novos limites de cada dimensão da matriz.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>Atributo "{0}" não pode ser aplicado a "{1}" de "{2}" porque o atributo não é válido neste tipo de declaração.</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>End Set' deve ser precedido por 'Set' correspondente.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Só há suporte para o comutador /embed ao emitir um PDB Portátil (/debug:portable ou /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>Interface "{0}" é ambígua com outra interface implementada "{1}" devido aos parâmetros "In" e "Out" em "{2}".</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>A instrução não pode aparecer dentro do corpo de uma interface.</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>"{0}" não é um parâmetro de método.</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>Continue While' só pode aparecer dentro de uma instrução 'While'.</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>Muito poucos argumentos para o método de extensão "{0}" definidos em "{1}".</value>
@@ -3955,7 +3973,7 @@
     <value>Método não pode possuir ambos os parâmetros ParamArray e Optional.</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>Método em uma estrutura não pode ser declarado 'Protected' ou 'Protected Friend'.</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>Variável de intervalo é assumida como sendo do tipo Object porque seu tipo não pode ser inferido. Use uma cláusula "As" para especificar um tipo diferente.</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>"MustInherit" não pode ser especificado para o tipo parcial "{0}" porque não pode ser combinado com "NotInheritable" especificado para um dos seus outros tipos parciais.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>Em um evento do Tempo de Execução do Windows, o tipo do parâmetro do método 'RemoveHandler' deve ser 'EventRegistrationToken'</value>
@@ -4325,161 +4346,164 @@
     <value>Is' esperado.</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Opções do Compilador do Visual Basic
+    <value>                  Visual Basic Compiler Options
 
-                                  – ARQUIVO DE SAÍDA –
-/out:&lt;file&gt;                       Especifica o nome do arquivo de saída.
-/target:exe                       Cria um aplicativo de console (padrão). 
-                                  (Forma abreviada: /t)
-/target:winexe                    Cria um aplicativo do Windows.
-/target:library                   Cria um assembly de biblioteca.
-/target:module                    Cria um módulo que pode ser adicionado a um 
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
                                   assembly.
-/target:appcontainerexe           Cria uma aplicativo do Windows que é executado no 
+/target:appcontainerexe           Create a Windows application that runs in 
                                   AppContainer.
-/target:winmdobj                  Cria um arquivo intermediário de metadados do Windows
-/doc[+|-]                         Gera um arquivo de documentação XML.
-/doc:&lt;file&gt;                       Gera um arquivo de documentação XML para &lt;file&gt;.
-/refout:&lt;file&gt;                    Saída do assembly de referência a ser gerado
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  – ARQUIVOS DE ENTRADA –
-/addmodule:&lt;file_list&gt;            Metadados de referência dos módulos especificados
-/link:&lt;file_list&gt;                 Insere metadados do assembly de interoperalidade 
-                                  especificado. (Forma abreviada: /l)
-/recurse:&lt;wildcard&gt;               Inclui todos os arquivos no diretório e subdiretórios 
-                                  atuais de acordo com as
-                                  especificações de curinga.
-/reference:&lt;file_list&gt;            Metadados de referência do assembly 
-                                  especificado. (Forma abreviada: /r)
-/analyzer:&lt;file_list&gt;             Executa os analisadores do assembly
-                                  (Forma abreviada: /a)
-/additionalfile:&lt;file list&gt;       Arquivos adicionais que não afetam diretamente a geração de
-                                  código, mas que podem ser usados por analisadores para produzir
-                                  erros ou avisos.
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  – RECURSOS –
-/linkresource:&lt;resinfo&gt;           Vincula o arquivo especificado como um 
-                                  recurso do assembly.
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
                                   resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
-                                  (Forma abreviada: /linkres)
-/nowin32manifest                  O manifesto padrão não deve ser inserido 
-                                  na seção do manifesto do PE de saída.
-/resource:&lt;resinfo&gt;               Adiciona o arquivo especificado como um recurso inserido do 
-                                  assembly.
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
                                   resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
-                                  (Forma abreviada: /res)
-/win32icon:&lt;file&gt;                 Especifica um arquivo de ícone Win32 (.ico) para os 
-                                  recursos Win32 padrão.
-/win32manifest:&lt;file&gt;             O arquivo fornecido é inserido na seção do manifesto
-                                  do PE de saída.
-/win32resource:&lt;file&gt;             Especifica um arquivo de recurso Win32 (.res).
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  – GERAÇÃO DE CÓDIGO –
-/optimize[+|-]                    Habilita otimizações.
-/removeintchecks[+|-]             Remove verificações de inteiros. O padrão é desligado.
-/debug[+|-]                       Emite informações de depuração.
-/debug:full                       Emite informações de depuração completas (padrão).
-/debug:pdbonly                    Emite informações de depuração completas.
-/debug:portable                   Emite informações de depuração multiplataforma.
-/debug:embedded                   Emite informações de depuração multiplataforma 
-                                  no .dll ou no .exe de destino.
-/deterministic                    Produz um assembly determinístico
-                                  (incluindo carimbo de data/hora e GUID da versão do módulo)
-/instrument:TestCoverage          Produz um assembly instrumentado para coletar
-                                  informações de cobertura
-/sourcelink:&lt;file&gt;                Informações do link de origem para inserir no PDB.
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  – ERROS E AVISOS –
-/nowarn                           Desabilita todos os avisos.
-/nowarn:&lt;number_list&gt;             Desabilita uma lista de avisos individuais.
-/warnaserror[+|-]                 Trata todos os avisos como erros.
-/warnaserror[+|-]:&lt;number_list&gt;   Trata uma lista de avisos como erros.
-/ruleset:&lt;file&gt;                   Especifica um arquivo de conjunto de regras que desabilita um diagnóstico
-                                  específico.
-/errorlog:&lt;file&gt;                  Especifica um arquivo para registrar todos os diagnósticos do compilador e do
-                                  analisador.
-/reportanalyzer                   Relata informações adicionais do analisador, como o
-                                  tempo de execução.
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-                                  – LINGUAGEM –
-/define:&lt;symbol_list&gt;             Declara os símbolos globais de 
-                                  compilação condicional. symbol_list:name=value,... 
-                                  (Forma abreviada: /d)
-/imports:&lt;import_list&gt;            Declara as importações globais dos namespaces nos 
-                                  arquivos de metadados referenciados. 
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
                                   import_list:namespace,...
-/langversion:&lt;number&gt;             Especifica a versão da linguagem: 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest
-/optionexplicit[+|-]              Exige declaração explícita de variáveis.
-/optioninfer[+|-]                 Permite inferência de tipos de variáveis.
-/rootnamespace:&lt;string&gt;           Especifica o Namespace raiz para todas as declarações 
-                                  de tipo.
-/optionstrict[+|-]                Impõe semântica de linguagem estrita.
-/optionstrict:custom              Avisa quando a semântica de linguagem estrita não é
-                                  respeitada.
-/optioncompare:binary             Especifica comparações de cadeia de caracteres de estilo binário.
-                                  Esse é o padrão.
-/optioncompare:text               Especifica comparações de cadeia de caracteres de estilo de texto.
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  – DIVERSOS –
-/help                             Exibe essa mensagem de uso. (Forma abreviada: /?)
-/noconfig                         Não inclui o arquivo VBC.RSP automaticamente.
-/nologo                           Não exibe o banner de direitos autorais do compilador.
-/quiet                            Modo de saída silencioso.
-/verbose                          Exibe mensagens detalhadas.
-/parallel[+|-]                    Build simultâneo. 
-/version                          Exibe o número de versão do compilador e sai.
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  – AVANÇADO –
-/baseaddress:&lt;number&gt;             O endereço básico de uma biblioteca ou módulo 
-                                  (hexadecimal).
-/checksumalgorithm:&lt;alg&gt;          Especifica o algoritmo para calcular a soma de verificação do 
-                                  arquivo de origem armazenado no PDB. Os valores com suporte são:
-                                  SHA1 (padrão) ou SHA256.
-/codepage:&lt;number&gt;                Especifica a página de código a ser usada ao abrir os 
-                                  arquivos de origem.
-/delaysign[+|-]                   Assinatura atrasada do assembly usando somente a parte pública
-                                  da chave de nome forte.
-/publicsign[+|-]                  Assinatura pública do assembly usando somente a parte pública
-                                  da chave do nome forte.
-/errorreport:&lt;string&gt;             Especifica como lidar com os erros internos do
-                                  compilador; deve ser avisar, enviar, nada ou colocar na fila
-                                  (padrão).
-/filealign:&lt;number&gt;               Especifica o alinhamento usado nas seções do arquivo de 
-                                  saída.
-/highentropyva[+|-]               Habilita ASLR de alta entropia.
-/keycontainer:&lt;string&gt;            Especifica um contêiner de chaves de nome forte.
-/keyfile:&lt;file&gt;                   Especifica um arquivo de chave de nome forte.
-/libpath:&lt;path_list&gt;              Lista de diretórios para pesquisar em relação a referências de 
-                                  metadados. (Delimitada por ponto e vírgula.)
-/main:&lt;class&gt;                     Especifica a Classe ou o Módulo que contém 
-                                  Sub Main. Também pode ser uma Classe 
-                                  herdada de System.Windows.Forms.Form. 
-                                  (Forma abreviada: /m)
-/moduleassemblyname:&lt;string&gt;      Nome do assembly do qual o módulo 
-                                  fará parte.
-/netcf                            Direciona ao .NET Compact Framework.
-/nostdlib                         Não referencia bibliotecas padrão 
-                                  (arquivo system.dll e VBC.RSP).
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
+                                  (hex).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
 /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                                  Especifica um mapeamento para nomes de caminhos de origem produzidos pelo
-                                  compilador.
-/platform:&lt;string&gt;                Limita em quais plataformas o código pode ser executado; 
-                                  deve ser x86, x64, Itanium, arm,
-                                  AnyCPU32BitPreferred ou anycpu (padrão).
-/preferreduilang                  Especifica o nome da linguagem de saída preferencial.
-/sdkpath:&lt;path&gt;                   Localização do diretório do SDK do .NET Framework
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
                                   (mscorlib.dll).
-/subsystemversion:&lt;version&gt;       Especifica a versão do subsistema do PE de saída. 
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
                                   version:&lt;number&gt;[.&lt;number&gt;]
-/utf8output[+|-]                  Emite a saída do compilador em codificação de caracteres 
-                                  UTF8.
-@&lt;file&gt;                           Insere configurações de linha de comando de um arquivo de texto
-/vbruntime[+|-|*]                 Compila com/sem o tempo de execução padrão do
-                                  Visual Basic.
-/vbruntime:&lt;file&gt;                 Compila com o tempo de execução alternativo do 
-                                  Visual Basic em &lt;file&gt;.
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4492,7 +4516,7 @@
     <value>"{0}" não pode substituir "{1}" porque diferem por restrições de parâmetros de tipo.</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>Argumento nomeado esperado.</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>Constante "{0}" não pode depender do seu próprio valor.</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.ru.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.ru.resx
@@ -447,7 +447,7 @@
     <value>Ссылка сборки "{0}" является недопустимой и не может быть разрешена.</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>Можно указать только один из модификаторов: "Public", "Private", "Protected", "Friend" или "Protected Friend".</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>Лямбда-выражение не будет удалено из этого обработчика событий</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>"{0}" имеет то же имя, что и член, используемый для типа "{1}" в группе "My". Переименуйте тип или его вложенное пространство имен.</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>"{0}" не является событием "{1}".</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>Тип "{0}" не может использоваться в этом контексте, так как "{0}" является параметром "Out".</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>"{0}" и "{1}" не могут перегружать друг друга, т. к. только один из них объявлен как "Default".</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>Не удается получить общий тип, так как возможно больше одного типа: предполагается "Object".</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>Ожидалась строковая константа.</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>В операторе "ReDim" требуется задать в скобках список новых границ для каждого измерения массива.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>Атрибут "{0}" не может использоваться для "{1}" из "{2}", поскольку данный атрибут не допускается для этого типа объявления.</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>Оператору "End Set" должен предшествовать соответствующий оператор "Set".</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>Параметр /embed поддерживается только при создании файлов Portable PDB (/debug:portable или /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>Интерфейс "{0}" неоднозначен с другим реализованным интерфейсом "{1}" из-за параметров "In" и "Out" в "{2}".</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>Оператор не может присутствовать в теле интерфейса.</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>"{0}" не является параметром метода.</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>"Continue While" может присутствовать только в операторе "While".</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>Слишком много аргументов в методе расширения "{0}", определенном в "{1}".</value>
@@ -3955,7 +3973,7 @@
     <value>Метод не может одновременно иметь параметры ParamArray и Optional.</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>Метод в структуре нельзя объявлять как "Protected" или "Protected Friend".</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>Предполагается, что переменная диапазона является типом Object, так как этот тип не может быть определен. Используйте предложение "As", чтобы указать другой тип.</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>"MustInherit" не может быть указан для разделяемого типа "{0}", так как не может быть объединен с "NotInheritable", указанным для одного из других разделяемых типов.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>В событии среды выполнения Windows тип параметра метода "RemoveHandler" должен иметь значение "EventRegistrationToken"</value>
@@ -4325,159 +4346,164 @@
     <value>Требуется "Is".</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Параметры компилятора Visual Basic
+    <value>                  Visual Basic Compiler Options
 
-                                  - ВЫХОДНОЙ ФАЙЛ -
-/out:&lt;файл&gt;                       Задает имя выходного файла.
-/target:exe                       Создать консольное приложение (по умолчанию). 
-                                  (Краткая форма: /t)
-/target:winexe                    Создать Windows-приложение.
-/target:library                   Создать библиотечную сборку.
-/target:module                    Создать модуль, который может быть добавлен в 
-                                  сборку.
-/target:appcontainerexe           Создать Windows-приложение, выполняемое в контейнере 
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
+                                  assembly.
+/target:appcontainerexe           Create a Windows application that runs in 
                                   AppContainer.
-/target:winmdobj                  Создать промежуточный файл метаданных Windows
-/doc[+|-]                         Создает XML-файл документации.
-/doc:&lt;файл&gt;                       Создает XML-файл документации &lt;файл&gt;.
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - ВХОДНЫЕ ФАЙЛЫ -
-/addmodule:&lt;список файлов&gt;                Ссылка на метаданные из заданного модуля
-/link:&lt;список файлов&gt;                     Внедрять метаданные из указанной сборки 
-                                  взаимодействия. (Краткая форма: /l)
-/recurse:&lt;подстановочный знак&gt;            Включить все файлы в текущем каталоге 
-                                  и подкаталогах в соответствии с
-                                  заданным шаблоном.
-/reference:&lt;список файлов&gt;                Указывать метаданные из заданной 
-                                  сборки. (Краткая форма: /r)
-/analyzer:&lt;список файлов&gt;                 Запускать анализаторы из этой сборки
-                                  (Краткая форма: /a)
-/additionalfile:&lt;список файлов&gt;           Дополнительные файлы, которые не оказывают прямого влияния на создание
-                                  кода, но могут использоваться анализаторами для вывода
-                                  ошибок или предупреждений.
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - РЕСУРСЫ -
-/linkresource:&lt;данные_о_ресурсе&gt;            Привязывает указанный файл в качестве внешнего 
-                                  ресурса сборки.
-                                  Данные о ресурсе: &lt;файл&gt;[,&lt;имя&gt;[,public|private]] 
-                                  (Краткая форма: /linkres)
-/nowin32manifest                  Манифест по умолчанию не должен внедряться 
-                                  в раздел манифеста выходного PE.
-/resource:&lt;данные_о_ресурсе&gt;                Добавляет указанный файл в качестве внедренного 
-                                  ресурса сборки.
-                                  Данные о ресурсе: &lt;файл&gt;[,&lt;имя&gt;[,public|private]] 
-                                  (Краткая форма: /res)
-/win32icon:&lt;файл&gt;                 Задает файл значка Win32 (ICO-файл) для 
-                                  ресурсов Win32 по умолчанию.
-/win32manifest:&lt;файл&gt;             Предоставленный файл внедряется в
-                                  раздел манифеста выходного PE.
-/win32resource:&lt;файл&gt;             Задает файл ресурсов Win32 (RES-файл).
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - СОЗДАНИЕ КОДА -
-/optimize[+|-]                    Включить оптимизацию.
-/removeintchecks[+|-]             Удалить проверки на целые числа. По умолчанию отключены.
-/debug[+|-]                       Выдать отладочную информацию.
-/debug:full                       Выдавать полные отладочные данные (по умолчанию).
-/debug:pdbonly                    Выдавать полные отладочные данные.
-/debug:portable                   Выдавать кроссплатформенные отладочные данные.
-/debug:embedded                   Выдавать кроссплатформенные отладочные данные в 
-                                  целевой DLL-файл или EXE-файл.
-/deterministic                    Создать детерминированную сборку
-                                  (включая GUID версии модуля и метку времени)
-/instrument:параметры               Задать параметры инструментирования.
-                                  Если не указано, инструментирование отключено.
-/sourcelink:&lt;файл&gt;                Данные о ссылке на исходные файлы для внедрения в Portable PDB.
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - ОШИБКИ И ПРЕДУПРЕЖДЕНИЯ -
-/nowarn                           Отключить все предупреждения.
-/nowarn:&lt;список чисел&gt;                   Отключить отдельные предупреждения.
-/warnaserror[+|-]                 Обрабатывать все предупреждения как ошибки.
-/warnaserror[+|-]:&lt;список чисел&gt;         Трактовать список предупреждений как ошибки.
-/ruleset:&lt;файл&gt;                   Указать файл набора правил, отключающий определенные
-                                  диагностические операции.
-/errorlog:&lt;файл&gt;                  Указать файл для записи всех диагностических данных
-                                  компилятора и анализатора.
-/reportanalyzer                   Сообщить дополнительные сведения об анализаторе, например
-                                  время выполнения.
-                                  - ЯЗЫК -
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-/define:&lt;список символов&gt;                 Объявить глобальные символы условной 
-                                  компиляции. Список символов:имя=значение,... 
-                                  (Краткая форма: /d)
-/imports:&lt;список_импорта&gt;         Объявить глобальные импорты для пространств имен в 
-                                  указанных файлах метаданных. 
-                                  список_импорта:пространство_имен,...
-/langversion:&lt;число&gt;              Указать языковую версию: 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|15.0|default
-/optionexplicit[+|-]              Требовать явного объявления переменных.
-/optioninfer[+|-]                 Разрешить вывод для типов переменных.
-/rootnamespace:&lt;строка&gt;           Задает корневое пространство имен для всех объявлений 
-                                  типов.
-/optionstrict[+|-]                Требовать строгой семантики языка.
-/optionstrict:custom              Предупреждать, когда не соблюдается строгая семантика 
-                                  языка.
-/optioncompare:binary             Задает сравнение строк как двоичных данных. 
-                                  Задано по умолчанию.
-/optioncompare:text               Задает сравнение строк как текста.
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
+                                  import_list:namespace,...
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - ПРОЧЕЕ -
-/help                             Отображать это сообщение об использовании. (Краткая форма: /?)
-/noconfig                         Файл VBC.RSP не включается в состав автоматически.
-/nologo                           Не отображать заставку компилятора с информацией об авторских правах.
-/quiet                            Режим вывода без сообщений.
-/verbose                          Отображать подробные сообщения.
-/parallel[+|-]                    Параллельная сборка. 
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - ДОПОЛНИТЕЛЬНО -
-/baseaddress:&lt;число&gt;              Базовый адрес библиотеки или модуля 
-                                  (шестнадцатеричный).
-/bugreport:&lt;файл&gt;                 Создать файл отчета об ошибках.
-/checksumalgorithm:&lt;алгоритм&gt;     Задать алгоритм расчета контрольной суммы 
-                                  исходного файла, хранимой в PDB. Поддерживаемые значения:
-                                  SHA1 (по умолчанию) или SHA256.
-/codepage:&lt;число&gt;                 Указывает кодовую страницу, используемую при открытии 
-                                  исходных файлов.
-/delaysign[+|-]                   Использовать отложенную подпись для сборки, применяя только
-                                  открытую часть ключа строгого имени.
-/publicsign[+|-]                  Подписать сборку, используя только открытую
-                                  часть ключа строгого имени.
-/errorreport:&lt;строка&gt;             Указывает способ обработки внутренних ошибок
-                                  компилятора; принимает prompt, send, none или queue
-                                  (по умолчанию).
-/filealign:&lt;число&gt;                Задать выравнивание для разделов выходных 
-                                  файлов.
-/highentropyva[+|-]               Включить технологию ASLR с высокой энтропией.
-/keycontainer:&lt;строка&gt;            Задает контейнер ключа для строгого имени.
-/keyfile:&lt;файл&gt;                   Задает файл ключа для строгого имени.
-/libpath:&lt;список_путей&gt;           Список каталогов для поиска ссылок на 
-                                  метаданные. (Разделитель — точка с запятой.)
-/main:&lt;класс&gt;                     Задает класс или модуль, содержащий 
-                                  Sub Main. Он может являться производным 
-                                  классом от System.Windows.Forms.Form. 
-                                  (Краткая форма: /m)
-/moduleassemblyname:&lt;строка&gt;      Имя сборки, частью которой будет 
-                                  данный модуль.
-/netcf                            Целевая версия .NET Compact Framework.
-/nostdlib                         Не обращаться к стандартным библиотекам 
-                                  (файл system.dll и VBC.RSP).
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
+                                  (hex).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
 /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                                  Указать сопоставление для выходных данных имен исходного пути по
-                                  компилятору.
-/platform:&lt;строка&gt;                Ограничить платформы, на которых может выполняться этот код: 
-                                  x86, x64, Itanium, arm,
-                                  AnyCPU32BitPreferred или anycpu (по умолчанию).
-/preferreduilang                  Указать имя предпочтительного языка вывода.
-/sdkpath:&lt;путь&gt;                   Расположение каталога пакета SDK .NET Framework
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
                                   (mscorlib.dll).
-/subsystemversion:&lt;версия&gt;        Указать версию подсистемы выходного PE-файла. 
-                                  версия: &lt;номер&gt;[.&lt;номер&gt;]
-/utf8output[+|-]                  Выдавать выходные данные компилятора в кодировке 
-                                  UTF8.
-@&lt;файл&gt;                           Вставить параметры командной строки из текстового файла
-/vbruntime[+|-|*]                 Скомпилировать с помощью или без использования стандартной среды выполнения
-                                  Visual Basic.
-/vbruntime:&lt;файл&gt;                 Скомпилировать с помощью альтернативной среды выполнения 
-                                  Visual Basic в &lt;файле&gt;.
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
+                                  version:&lt;number&gt;[.&lt;number&gt;]
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4490,7 +4516,7 @@
     <value>"{0}" не может переопределить "{1}", так как они отличаются по ограничениям параметра типа.</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>Требуется именованный аргумент.</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>Константа "{0}" не может зависеть от своего собственного значения.</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.tr.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.tr.resx
@@ -447,7 +447,7 @@
     <value>'{0}' derleme başvurusu geçersiz ve çözülemiyor.</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>'Public', 'Private', 'Protected', 'Friend' veya 'Protected Friend' seçeneklerinden yalnızca biri belirtilebilir.</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>Lambda ifadesi bu olay işleyicisinden kaldırılmayacak</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>'{0}' öğesinin adı, 'My' grubunda açılan '{1}' türü için kullanılan bir üyenin adıyla aynı. Türü veya onu kapsayan ad alanını yeniden adlandırın.</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>'{0}', bir '{1}' olayı değil.</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>'{0}' bir 'Out' tür parametresi olduğundan, bu bağlamda '{0}' türü kullanılamaz.</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>Yalnızca biri 'Default' olarak bildirildiğinden, '{0}' ve '{1}' birbirini aşırı yükleyemez.</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>Birden fazla tür olasılığı olduğu için ortak bir tür çıkarsanamıyor: 'Object' varsayıldı.</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>Dize sabiti bekleniyor.</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>'ReDim' deyimleri, her bir dizi boyutunun yeni sınırlarının ayraç içine alınmış bir listesini gerektirir.</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>'{0}' özniteliği bu bildirim türünde geçerli olmadığından '{2}' '{1}' öğesine uygulanamaz.</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>'End Set' öncesinde eşleşen bir 'Set' olmalıdır.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>/embed anahtarı yalnızca Taşınabilir PDB gösterilirken desteklenir (/debug:portable veya /debug:embedded).</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>'{2}' içindeki 'In' ve 'Out' parametreleri nedeniyle '{0}' arabirimi uygulanmış diğer '{1}' arabirimiyle birlikte belirsiz.</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>Arabirim gövdesi içinde deyim yer alamaz.</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>'{0}' bir yöntem parametresi değil.</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>'Continue While' yalnızca bir 'While' deyimi içinde bulunabilir.</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>'{1}' içinde tanımlanan '{0}' genişletme yöntemi için çok fazla bağımsız değişken var.</value>
@@ -3955,7 +3973,7 @@
     <value>Yöntemde hem ParamArray hem de Optional parametreleri olamaz.</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>Yapı içindeki yöntem 'Protected' veya 'Protected Friend' olarak bildirilemez.</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>Aralık değişkeninin türü çıkarsanamadığından, Object türünde olduğu varsayıldı. Başka bir tür belirtmek için 'As' yan tümcesi kullanın.</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>Diğer kısmi türlerinden biri için belirtilen 'NotInheritable' ile birleştirilemeyeceğinden, '{0}' kısmi türü için 'MustInherit' belirtilemez.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>Windows Çalışma Zamanı olayında ‘RemoveHandler’ metot parametresinin türü 'EventRegistrationToken' olmalıdır</value>
@@ -4325,160 +4346,164 @@
     <value>'Is' bekleniyor.</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Visual Basic Derleyici Seçenekleri
+    <value>                  Visual Basic Compiler Options
 
-                                  - ÇIKIŞ DOSYASI -
-/out:&lt;dosya&gt;                       Çıkış dosyası adını belirtir.
-/target:exe                       Konsol uygulaması oluştur (varsayılan). 
-                                  (Kısa biçim: /t)
-/target:winexe                    Windows uygulaması oluştur.
-/target:library                   Kitaplık bütünleştirilmiş kodu oluştur.
-/target:module                    Bütünleştirilmiş koda eklenebilecek modül 
-                                  oluştur.
-/target:appcontainerexe           AppContainer içinde çalışan Windows 
-                                  uygulaması oluştur.
-/target:winmdobj                  Windows Meta Veri ara dosyası oluştur
-/doc[+|-]                         XML belge dosyası oluşturur.
-/doc:&lt;dosya&gt;                       &lt;dosya&gt; içinde XML belge dosyası oluşturur.
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
+                                  assembly.
+/target:appcontainerexe           Create a Windows application that runs in 
+                                  AppContainer.
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - GİRİŞ DOSYALARI -
-/addmodule:&lt;dosya_listesi&gt;            Belirtilen modüllerdeki meta verilere başvur
-/link:&lt;dosya_listesi&gt;                 Belirtilen birlikte çalışma bütünleştirilmiş kodundaki meta verileri 
-                                  ekle. (Kısa biçim: /l)
-/recurse:&lt;joker karakter&gt;               Bu dizin ve alt dizinlerdeki
-                                  tüm dosyaları joker karakter belirtimlerine 
-                                  göre ekle.
-/reference:&lt;dosya_listesi&gt;            Belirtilen bütünleştirilmiş koddaki meta verilere 
-                                  başvur. (Kısa biçim: /r)
-/analyzer:&lt;dosya_listesi&gt;             Çözümleyicileri bu bütünleştirilmiş koddan çalıştır
-                                  (Kısa biçim: /a)
-/additionalfile:&lt;dosya_listesi&gt;       Kod oluşturmayı doğrudan etkilemeyen, ancak
-                                  çözümleyicilerin hata veya uyarı oluşturmak
-                                  için kullanılabileceği ek dosyalar.
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - KAYNAKLAR -
-/linkresource:&lt;kaynak bilgisi&gt;           Belirtilen dosyayı dış bütünleştirilmiş kod kaynağı 
-                                  olarak bağlar.
-                                  resinfo:&lt;dosya&gt;[,&lt;ad&gt;[,public|private]] 
-                                  (Kısa biçim: /linkres)
-/nowin32manifest                  Varsayılan bildirim dosyası, çıkış PE'sinin 
-                                  bildirim bölümüne eklenmemelidir.
-/resource:&lt;kaynak bilgisi&gt;               Belirtilen dosyayı eklenen bütünleştirilmiş kod 
-                                  kaynağı olarak ekler.
-                                  resinfo:&lt;dosya&gt;[,&lt;ad&gt;[,public|private]] 
-                                  (Kısa biçim: /res)
-/win32icon:&lt;dosya&gt;                 Varsayılan Win32 kaynakları için Win32 
-                                  simge dosyası (.ico) belirtir.
-/win32manifest:&lt;dosya&gt;             Belirtilen dosya, çıkış PE'sinin bildirim
-                                  bölümüne eklenir.
-/win32resource:&lt;dosya&gt;             Win32 kaynak dosyası (.res) belirtir.
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - KOD OLUŞTURMA -
-/optimize[+|-]                    İyileştirmeleri etkinleştir.
-/removeintchecks[+|-]             Tamsayı denetimlerini kaldır. Varsayılan olarak kapalı.
-/debug[+|-]                       Hata ayıklama bilgilerini yayınla.
-/debug:full                       Tam hata ayıklama bilgilerini yayınla (varsayılan).
-/debug:pdbonly                   Tam hata ayıklama bilgilerini yayınla.
-/debug:portable                    Platformlar arası hata ayıklama bilgilerini yayınla.
-/debug:embedded                   Platformlar arası hata ayıklama bilgilerini 
-                                  hedef .dll veya .exe dosyasında yayınla.
-/deterministic                    Belirlenimci bütünleştirilmiş kod dosyası oluştur
-                                  (modül sürüm GUID'si ve zaman damgası içerir)
-/instrument:TestCoverage          Kapsam bilgilerini toplamak için işaretlenen
-                                  bir bütünleştirilmiş kod oluştur
-/sourcelink:&lt;dosya&gt;                PDB'ye eklenecek kaynak bağlantı bilgileri.
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - HATA VE UYARILAR  -
-/nowarn                           Tüm uyarıları devre dışı bırak.
-/nowarn:&lt;numara_listesi&gt;             Listelenen uyarıları devre dışı bırak.
-/warnaserror[+|-]                 Tüm uyarıları hata olarak işle.
-/warnaserror[+|-]:&lt;numara_listesi&gt;   Listelenen uyarıları hata olarak işle.
-/ruleset:&lt;dosya&gt;                   Belirli tanılamaları devre dışı bırakan bir kural
-                                  kümesi dosyası belirt.
-/errorlog:&lt;dosya&gt;                  Tüm derleyici ve çözümleyici tanılamalarının günlüğe kaydedileceği bir dosya
-                                  belirt.
-/reportanalyzer                   Yürütme zamanı gibi ek çözümleyici
-                                  bilgilerini bildir.
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-                                  - DİL -
-/define:&lt;sembol_listesi&gt;             Genel koşullu derleme sembolleri bildir. 
-                                  sembol_listesi:ad=değer,... 
-                                  (Kısa biçim: /d)
-/imports:&lt;içeri_aktarma_listesi&gt;            Başvurulan meta veri dosyalarındaki ad 
-                                  alanları için genel İçeri aktarma dosyaları bildir. 
-                                  içeri_aktarma_listesi:ad alanı,...
-/langversion:&lt;sayı&gt;             Dil sürümünü belirt: 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest
-/optionexplicit[+|-]              Değişkenlerin açık bir şekilde bildirilmesini gerektir.
-/optioninfer[+|-]                 Değişkenlerde tür çıkarımına izin ver.
-/rootnamespace:&lt;dize&gt;           Tüm tür bildirimleri için kök Ad Alanını 
-                                  belirtir.
-/optionstrict[+|-]                Katı dil kurallarını uygula.
-/optionstrict:custom              Katı dil kurallarına uyulmadığında 
-                                  uyar.
-/optioncompare:binary             İkili stil dize karşılaştırmalarını belirt. 
-                                  Bu varsayılandır.
-/optioncompare:text               Metin stili dize karşılaştırmalarını belirt.
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
+                                  import_list:namespace,...
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - ÇEŞİTLİ -
-/help                             Bu kullanım iletisini göster. (Kısa biçim: /?)
-/noconfig                         VBC.RSP dosyasını otomatik olarak ekleme.
-/nologo                           Derleyici telif hakkı başlığını gösterme.
-/quiet                            Sessiz çıkış modu.
-/verbose                          Ayrıntılı iletileri görüntüle.
-/parallel[+|-]                    Eşzamanlı derleme. 
-/version                          Derleyici sürüm numarasını görüntüle ve çıkış yap.
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - GELİŞMİŞ -
-/baseaddress:&lt;sayı&gt;             Kitaplık veya modülün taban adresi 
-                                  (onaltılık).
-/checksumalgorithm:&lt;alg&gt;          PDB'de depolanan kaynak dosya sağlama toplamını 
-                                  hesaplama algoritmasını belirt. Desteklenen değerler:
-                                  SHA1 (varsayılan) veya SHA256.
-/codepage:&lt;sayı&gt;                Kaynak dosyalar açılırken kullanılacak kod 
-                                  sayfasını belirtir.
-/delaysign[+|-]                   Bütünleştirilmiş kodu, tanımlayıcı ad anahtarının yalnızca genel
-                                  kısmıyla geç imzala.
-/publicsign[+|-]                  Bütünleştirilmiş kodu, tanımlayıcı ad anahtarının yalnızca genel
-                                  bölümüyle genel olarak imzala.
-/errorreport:&lt;dize&gt;             İç derleyici hatalarını işleme yöntemini
-                                  belirtir; prompt, send, none veya queue
-                                  (varsayılan) olmalıdır.
-/filealign:&lt;sayı&gt;               Çıkış dosyası bölümleri için kullanılan hizalamayı 
-                                  belirt.
-/highentropyva[+|-]               Yüksek entropili ASLR'yi etkinleştir.
-/keycontainer:&lt;dize&gt;            Tanımlayıcı ad anahtarı kapsayıcısı belirtir.
-/keyfile:&lt;dosya&gt;                   Tanımlayıcı ad anahtarı dosyası belirtir.
-/libpath:&lt;yol_listesi&gt;              Meta veri başvuruları için aranacak dizin 
-                                  listesi. (Noktalı virgülle ayrılmış.)
-/main:&lt;sınıf&gt;                     Sub Main'i içeren Class veya Module'ü 
-                                  belirtir. System.Windows.Forms.Form'dan 
-                                  devralan bir Class da olabilir. 
-                                  (Kısa biçim: /m)
-/moduleassemblyname:&lt;dize&gt;      Bu modülün bir parçası olacağı bütünleştirilmiş kodun 
-                                  adı.
-/netcf                            .NET Compact Framework'ü hedefle.
-/nostdlib                         Standart kitaplıklara (system.dll ve VBC.RSP dosyası) 
-                                  başvurma.
-/pathmap:&lt;A1&gt;=&lt;D1&gt;,&lt;A2&gt;=&lt;D2&gt;,...
-                                  Derleyici tarafından kaynak yolu adları çıkışı için bir eşleme
-                               belirt.
-/platform:&lt;dize&gt;                Bu kodun çalışabileceği platformları sınırla; 
-                                  x86, x64, Itanium, arm, AnyCPU32BitPreferred
-                                  veya anycpu (varsayılan) olmalıdır.
-/preferreduilang                  Tercih edilen çıkış dilini belirt.
-/sdkpath:&lt;yol&gt;                   .NET Framework SDK (mscorlib.dll) dizininin
-                                  konumu.
-/subsystemversion:&lt;sürüm&gt;       Çıkış PE'nin alt sistem sürümünü belirt. 
-                                  version:&lt;sayı&gt;[.&lt;sayı&gt;]
-/utf8output[+|-]                  Derleyici çıkışını UTF8 kodlamasıyla 
-                                  yayınla.
-@&lt;dosya&gt;                           Metin dosyasından komut satırı ayarlarını ekle.
-/vbruntime[+|-|*]                 Varsayılan Visual Basic çalışma zamanı dosyasıyla/
-                                  dosyası olmadan derle.
-/vbruntime:&lt;dosya&gt;                 &lt;dosya&gt; içindeki alternatif Visual Basic çalışma zamanıyla 
-                                  derle.
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
+                                  (hex).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
+/pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
+                                  (mscorlib.dll).
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
+                                  version:&lt;number&gt;[.&lt;number&gt;]
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4491,7 +4516,7 @@
     <value>Tür parametresi kısıtlamaları farklı olduğundan '{0}', '{1}' sınıfını geçersiz kılamaz.</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>Adlandırılmış bağımsız değişken bekleniyor.</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>'{0}' sabiti kendi değerine bağımlı olamaz.</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.zh-Hans.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.zh-Hans.resx
@@ -447,7 +447,7 @@
     <value>程序集引用“{0}”无效，无法解析。</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>只能指定 "Public"、"Private"、"Protected"、"Friend" 或 "Protected Friend" 中的一个。</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>Lambda 表达式将不会从此事件处理程序中删除</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>“{0}”与“My”组中公开的类型“{1}”所使用的成员同名。请重命名该类型或其封闭命名空间。</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>“{0}”不是“{1}”的事件。</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>类型“{0}”不能用于此上下文，因为“{0}”是“Out”类型参数。</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>“{0}”和“{1}”中只有一个声明为“Default”，因此它们无法相互重载。</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>无法推断通用类型，因为可能存在多个类型；假定为 "Object"。</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>应为字符串常量。</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>"ReDim" 语句需要一个带括号的列表，该列表列出数组每个维度的新界限。</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>属性“{0}”不能应用于“{2}”的“{1}”，因为该属性在此声明类型中无效。</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>“End Set”前面必须是匹配的“Set”。</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>/仅在发出可移植 PDB 时支持嵌入式开关(/debug:portable 或 /debug:embedded)。</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>“{2}”中的“In”和“Out”参数导致接口“{0}”与另一个已实现的接口“{1}”一起使用时目的不明确。</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>语句不能出现在接口体内。</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>“{0}”不是方法参数。</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>“Continue While”只能出现在“While”语句内。</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>对“{1}”中定义的扩展方法“{0}”而言，参数太多。</value>
@@ -3955,7 +3973,7 @@
     <value>方法不能同时具有 ParamArray 和 Optional 参数。</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>结构中的方法不能声明为 "Protected" 或 "Protected Friend"。</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>假定范围变量属于对象类型，因为无法推断其类型。请使用“As”子句指定不同类型。</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>“MustInherit”不能为分部类型“{0}”指定，因为它不能与为该类型的某个其他分部类型指定的“NotInheritable”组合。。</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>在 Windows Runtime 事件中，“RemoveHandler”方法参数的类型必须为“EventRegistrationToken”</value>
@@ -4325,162 +4346,164 @@
     <value>应为 "Is"。</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Visual Basic 编译器选项
+    <value>                  Visual Basic Compiler Options
 
-                                  - 输出文件 -
-/out:&lt;file&gt;                       指定输出文件名称。
-/target:exe                       创建控制台应用程序(默认)。
-                                  (缩写: /t)
-/target:winexe                    创建 Windows 应用程序。
-/target:library                   创建库程序集。
-/target:module                    创建可添加到程序集的
-                                  模块。
-/target:appcontainerexe           创建在 AppContainer 中运行的
-                                  Windows 应用程序。
-/target:winmdobj                  创建 Windows 元数据中间文件
-/doc[+|-]                         生成 XML 文档文件。
-/doc:&lt;file&gt;                       将 XML 文档文件生成到 &lt;file&gt;
-/refout:&lt;file&gt;                    引用要生成的引用程序集
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
+                                  assembly.
+/target:appcontainerexe           Create a Windows application that runs in 
+                                  AppContainer.
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - 输入文件 -
-/addmodule:&lt;file_list&gt;            从指定模块中引用元数据
-/link:&lt;file_list&gt;                 嵌入指定互操作程序集中的
-                                  元数据。(缩写: /l)
-/recurse:&lt;wildcard&gt;               根据通配符规范包括
-                                  当前目录和子目录中
-                                  的所有文件。
-/reference:&lt;file_list&gt;            从指定程序集中引用
-                                  元数据。(缩写: /r)
-/analyzer:&lt;file_list&gt;             运行此程序集的分析器
-                                  (缩写: /a)
-/additionalfile:&lt;file list&gt;       不直接影响代码
-                                  生成但可能被分析器用于生成
-                                  错误或警告的其他文件。
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - 资源 -
-/linkresource:&lt;resinfo&gt;           将指定文件作为外部
-                                  程序集资源进行链接。
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
                                   resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
-                                  (缩写: /linkres)
-/nowin32manifest                  默认清单不应嵌入
-                                  输出 PE 的清单部分。
-/resource:&lt;resinfo&gt;               将指定文件作为嵌入式
-                                  程序集资源进行添加。
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
                                   resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
-                                  (缩写: /res)
-/win32icon:&lt;file&gt;                 为默认的 Win32 资源
-                                  指定 Win32 图标文件(.ico)。
-/win32manifest:&lt;file&gt;             提供的文件嵌入在
-                                  输出 PE 的清单部分。
-/win32resource:&lt;file&gt;             指定 Win32 资源文件(.res)。
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - 代码生成 -
-/optimize[+|-]                    启用优化。
-/removeintchecks[+|-]             删除整数检查。默认为“关”。
-/debug[+|-]                       发出调试信息。
-/debug:full                       发出完全调试信息(默认)。
-/debug:pdbonly            发出完全调试信息。
-/debug:portable                   发出跨平台调试信息。
-/debug:embedded                   发出跨平台调试信息到
-                                  目标 .dll 或 .exe.
-/deterministic                    生成确定性程序集
-                                  (包括模块版本 GUID 和时间戳) 
-/refonly                          生成引用程序集来替代主要输出
-/instrument:TestCoverage          生成对其检测以收集覆盖率信息的t
-                                  程序集
-/sourcelink:&lt;file&gt;                要嵌入到可移植 PDB 中的源链接。
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - 错误和警告 -
-/nowarn                           禁用所有警告。
-/nowarn:&lt;number_list&gt;             禁用个人警告列表。
-/warnaserror[+|-]                 将所有警告视为错误。
-/warnaserror[+|-]:&lt;number_list&gt;   将警告列表视为错误。
-/ruleset:&lt;file&gt;                   指定禁用特定诊断的
-                                  规则集文件。
-/errorlog:&lt;file&gt;                  指定用于记录所有编译器和分析器诊断的
-                                  文件。
-/reportanalyzer                   报告其他分析器信息，如
-                                  执行时间。
-                                  - 语言 -
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-/define:&lt;symbol_list&gt;             声明全局条件编译
-                                  符号。symbol_list:name=value,... 
-                                  (缩写: /d)
-/imports:&lt;import_list&gt;            为引用的元数据文件中的命名空间声明
-                                  全局导入。
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
                                   import_list:namespace,...
-/langversion:&lt;number&gt;             指定语言版本: 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest
-/optionexplicit[+|-]              需要变量的显式声明。
-/optioninfer[+|-]                 允许变量的类型推理。
-/rootnamespace:&lt;string&gt;           指定所有类型声明的根
-                                  命名空间。
-/optionstrict[+|-]                强制严格语言语义。
-/optionstrict:custom              不遵从严格语言语义时
-                                  发出警告。
-/optioncompare:binary             指定二进制样式的字符串比较。
-                                  这是默认设置。
-/optioncompare:text               指定文本样式字符串比较。
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - 杂项 -
-/help                             显示此用法消息。(缩写: /?)
-/noconfig                         不自动包括 VBC.RSP 文件。
-/nologo                           不显示编译器版权横幅。
-/quiet                            安静输出模式。
-/verbose                          显示详细消息。
-/parallel[+|-]                    并发生成。
-/version                          显示编译器版本号并退出。
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - 高级 -
-/baseaddress:&lt;number&gt;             库或模块的基址
-                                  (十六进制)。
-/checksumalgorithm:&lt;alg&gt;          指定计算存储在 PDB 中的源文件校验和
-                                  的算法。支持的值是:
-                                  SHA1 (默认)或 SHA256。
-/codepage:&lt;number&gt;                指定打开源文件时要使用的
-                                  代码页。
-/delaysign[+|-]                   仅使用强名称密钥的公共部分
-                                  对程序集进行延迟签名。
-/publicsign[+|-]                  仅使用强名称密钥的公共部分
-                                  对程序集进行公共签名
-/errorreport:&lt;string&gt;             指定处理内部编译器错误的方式；
-                                  必须是 prompt、send、none 或 queue
-                                  (默认)。
-/filealign:&lt;number&gt;               指定用于输出文件节的对齐
-                                  方式。
-/highentropyva[+|-]               启用高平均信息量的 ASLR。
-/keycontainer:&lt;string&gt;            指定强名称密钥容器。
-/keyfile:&lt;file&gt;                   指定强名称密钥文件。
-/libpath:&lt;path_list&gt;              搜索元数据引用的目录
-                                  列表。(分号分隔。)
-/main:&lt;class&gt;                     指定包含 Sub Main 的类
-                                  或模块。也可为从
-                                  System.Windows.Forms.Form 继承的类。
-                                  (缩写: /m)
-/moduleassemblyname:&lt;string&gt;      此模块所属程序集
-                                  的名称。
-/netcf                            以 .NET Compact Framework 为目标。
-/nostdlib                         不引用标准库
-                                  (system.dll 和 VBC.RSP 文件)。
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
+                                  (hex).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
 /pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
-                                  按编译器指定源路径名称输出的
-                                  映射。
-/platform:&lt;string&gt;                限制此代码可以在其上运行的平台；
-                                  必须是 x86、x64、Itanium、arm、
-                                  AnyCPU32BitPreferred 或 anycpu (默认)。
-/preferreduilang                  指定首选输出语言名称。
-/sdkpath:&lt;path&gt;                   .NET Framework SDK 目录的位置
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
                                   (mscorlib.dll).
-/subsystemversion:&lt;version&gt;       指定输出 PE 的子系统版本。
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
                                   version:&lt;number&gt;[.&lt;number&gt;]
-/utf8output[+|-]                  以 UTF8 字符编码格式
-                                  发出编译器输出。
-@&lt;file&gt;                           从文本文件插入命令行设置
-/vbruntime[+|-|*]                 用/不用默认的 Visual Basic
-                                  运行时进行编译。
-/vbruntime:&lt;file&gt;                 使用 &lt;file&gt; 中的备用 Visual Basic 运行时
-                                  进行编译。
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4493,7 +4516,7 @@
     <value>“{0}”无法重写“{1}”，因为它们在类型参数约束上存在差异。</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>应为命名参数。</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>常量“{0}”不能依赖自身的值。</value>

--- a/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.zh-Hant.resx
+++ b/src/Microsoft.CodeAnalysis.VisualBasic/VBResources.zh-Hant.resx
@@ -447,7 +447,7 @@
     <value>組件參考 '{0}' 無效，無法解析。</value>
   </data>
   <data name="ERR_DuplicateAccessCategoryUsed" xml:space="preserve">
-    <value>只可以指定 'Public'、'Private'、'Protected'、'Friend' 或 'Protected Friend' 其中之一。</value>
+    <value>Only one of 'Public', 'Private', 'Protected', 'Friend', 'Protected Friend', or 'Private Protected' can be specified.</value>
   </data>
   <data name="WRN_LambdaPassedToRemoveHandler_Title" xml:space="preserve">
     <value>將不會從這個事件處理常式中移除 Lambda 運算式</value>
@@ -717,6 +717,9 @@
   <data name="ERR_PropertyNameConflictInMyCollection" xml:space="preserve">
     <value>'{0}' 與用在 'My' 群組中所公開之類型 '{1}' 的成員，有相同的名稱。請重新命名類型或其內含的命名空間。</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_NameNotEvent2" xml:space="preserve">
     <value>'{0}' 不是 '{1}' 的事件。</value>
   </data>
@@ -752,6 +755,9 @@
   </data>
   <data name="ERR_VarianceOutParamDisallowed1" xml:space="preserve">
     <value>類型 '{0}' 無法用於此內容中，因為 '{0}' 是 'Out' 類型參數。</value>
+  </data>
+  <data name="ERR_InvalidDebugInfo" xml:space="preserve">
+    <value>Unable to read debug information of method '{0}' (token 0x{1}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DefaultMissingFromProperty2" xml:space="preserve">
     <value>'{0}' 和 '{1}' 無法互相多載，因為只有一個宣告為 'Default'。</value>
@@ -946,6 +952,9 @@
   </data>
   <data name="WRN_IfTooManyTypesObjectAssumed" xml:space="preserve">
     <value>無法推斷一般類型，因為可能的類型不止一種; 假設是 'Object'。</value>
+  </data>
+  <data name="FEATURE_LeadingDigitSeparator" xml:space="preserve">
+    <value>leading digit separator</value>
   </data>
   <data name="ERR_ExpectedStringLiteral" xml:space="preserve">
     <value>必須有字串常數。</value>
@@ -1446,6 +1455,9 @@
   <data name="ERR_RedimNoSizes" xml:space="preserve">
     <value>ReDim' 陳述式需要每個陣列維度新界限的括號清單。</value>
   </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
+  </data>
   <data name="ERR_InvalidAttributeUsageOnAccessor" xml:space="preserve">
     <value>無法將屬性 '{0}' 套用至 '{2}' 的 '{1}'，因為該屬性在此宣告類型上無效。</value>
   </data>
@@ -1912,7 +1924,7 @@
     <value>End Set' 之前必須搭配相對應的 'Set'。</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
-    <value>發出可攜式 PDB 時才支援 /embed 參數 (/debug:portable 或 /debug:embedded)。</value>
+    <value>/embed switch is only supported when emitting a PDB.</value>
   </data>
   <data name="WRN_VarianceDeclarationAmbiguous3" xml:space="preserve">
     <value>因為 '{2}' 中 'In' 和 'Out' 參數而造成介面 '{0}' 與另一個實作介面 '{1}' 之間模稜兩可。</value>
@@ -2221,6 +2233,9 @@
   </data>
   <data name="ERR_InvInsideInterface" xml:space="preserve">
     <value>陳述式不能出現在介面主體內。</value>
+  </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
   </data>
   <data name="ERR_NamedParamNotFound1" xml:space="preserve">
     <value>'{0}' 不是方法參數。</value>
@@ -2533,6 +2548,9 @@
   </data>
   <data name="ERR_ContinueWhileNotWithinWhile" xml:space="preserve">
     <value>Continue While' 只可以在 'While' 陳述式中出現。</value>
+  </data>
+  <data name="FEATURE_PrivateProtected" xml:space="preserve">
+    <value>Private Protected</value>
   </data>
   <data name="ERR_TooManyArgs2" xml:space="preserve">
     <value>在 '{1}' 中定義的擴充方法 '{0}'，有太多引數。</value>
@@ -3955,7 +3973,7 @@
     <value>方法不可以同時有 ParamArray 和 Optional 引數。</value>
   </data>
   <data name="ERR_StructureCantUseProtected" xml:space="preserve">
-    <value>結構中的方法不可宣告為 'Protected' 或 'Protected Friend'。</value>
+    <value>Method in a structure cannot be declared 'Protected', 'Protected Friend', or 'Private Protected'.</value>
   </data>
   <data name="WRN_QueryMissingAsClauseinVarDecl" xml:space="preserve">
     <value>因為無法推斷範圍變數的類型，所以會將其假設為 Object 類型。請使用 'As' 子句指定不同的類型。</value>
@@ -3965,6 +3983,9 @@
   </data>
   <data name="ERR_PartialTypeBadMustInherit1" xml:space="preserve">
     <value>不可為部分類型 '{0}' 指定 'MustInherit'，因為其無法與針對某個其他部分類型所指定的 'NotInheritable' 相結合。</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="ERR_RemoveParamWrongForWinRT" xml:space="preserve">
     <value>在 Windows 執行階段事件中，'RemoveHandler' 方法參數的類型必須是 'EventRegistrationToken'</value>
@@ -4325,162 +4346,164 @@
     <value>必須是 'Is'。</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
-    <value>                  Visual Basic 編譯器選項
+    <value>                  Visual Basic Compiler Options
 
-                                  - 輸出檔案 -
-/out:&lt;檔案&gt;                       指定輸出檔案名稱。
-/target:exe                       建立主控台應用程式 (預設)。
-                                  (簡短形式: /t)
-/target:winexe                    建立 Windows 應用程式。
-/target:library                   建立程式庫組件。
-/target:module                    建立可加入組件的
-                                  模組。
-/target:appcontainerexe           建立可在 AppContainer 中執行的
-                                  Windows 應用程式。
-/target:winmdobj                  建立 Windows 中繼資料中繼檔案
-/doc[+|-]                         產生 XML 文件檔案。
-/doc:&lt;檔案&gt;                       將產生的 XML 文件檔案儲存至 &lt;檔案&gt;。
-/refout:&lt;檔案&gt;                    要產生的參考組件輸出。
+                                  - OUTPUT FILE -
+/out:&lt;file&gt;                       Specifies the output file name.
+/target:exe                       Create a console application (default). 
+                                  (Short form: /t)
+/target:winexe                    Create a Windows application.
+/target:library                   Create a library assembly.
+/target:module                    Create a module that can be added to an 
+                                  assembly.
+/target:appcontainerexe           Create a Windows application that runs in 
+                                  AppContainer.
+/target:winmdobj                  Create a Windows Metadata intermediate file
+/doc[+|-]                         Generates XML documentation file.
+/doc:&lt;file&gt;                       Generates XML documentation file to &lt;file&gt;.
+/refout:&lt;file&gt;                    Reference assembly output to generate
 
-                                  - 輸入檔案 -
-/addmodule:&lt;檔案清單&gt;            從指定的模組參考中繼資料
-/link:&lt;檔案清單&gt;                 從指定的 Interop 組件內嵌
-                                  中繼資料。(簡短形式: /l)
-/recurse:&lt;萬用字元&gt;               依據指定的萬用字元，
-                                  併入目前的目錄及
-                                  子目錄中的所有檔案。
-/reference:&lt;檔案清單&gt;            從指定的組件參考
-                                  中繼資料。(簡短形式: /r)
-/analyzer:&lt;檔案清單&gt;             從此組件執行分析器
-                                  (簡短形式: /a)
-/additionalfile:&lt;檔案清單&gt;       不會直接影響程式碼產生，
-                                  但分析器可用以產生錯誤或警告的
-                                  其他檔案。
+                                  - INPUT FILES -
+/addmodule:&lt;file_list&gt;            Reference metadata from the specified modules
+/link:&lt;file_list&gt;                 Embed metadata from the specified interop 
+                                  assembly. (Short form: /l)
+/recurse:&lt;wildcard&gt;               Include all files in the current directory 
+                                  and subdirectories according to the
+                                  wildcard specifications.
+/reference:&lt;file_list&gt;            Reference metadata from the specified 
+                                  assembly. (Short form: /r)
+/analyzer:&lt;file_list&gt;             Run the analyzers from this assembly
+                                  (Short form: /a)
+/additionalfile:&lt;file list&gt;       Additional files that don't directly affect code
+                                  generation but may be used by analyzers for producing
+                                  errors or warnings.
 
-                                  - 資源 -
-/linkresource:&lt;resinfo&gt;           連結指定的檔案作為外部
-                                  組件資源。
-                                  resinfo:&lt;檔案&gt;[,&lt;名稱&gt;[,公開|私用]] 
-                                  (簡短形式: /linkres)
-/nowin32manifest                  預設資訊清單不應內嵌在輸出 PE 的
-                                  資訊清單區段中。
-/resource:&lt;resinfo&gt;               加入指定的檔案作為內嵌的
-                                  組件資源。
-                                  resinfo:&lt;檔案&gt;[,&lt;名稱&gt;[,公開|私用]] 
-                                  (簡短形式: /res)
-/win32icon:&lt;檔案&gt;                 為預設的 Win32 資源，
-                                  指定 Win32 圖示檔 (.ico)。
-/win32manifest:&lt;檔案&gt;             所提供的檔案，會內嵌在輸出 PE 的
-                                  資訊清單區段中。
-/win32resource:&lt;檔案&gt;             指定 Win32 資源檔 (.res)。
+                                  - RESOURCES -
+/linkresource:&lt;resinfo&gt;           Links the specified file as an external 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /linkres)
+/nowin32manifest                  The default manifest should not be embedded 
+                                  in the manifest section of the output PE.
+/resource:&lt;resinfo&gt;               Adds the specified file as an embedded 
+                                  assembly resource.
+                                  resinfo:&lt;file&gt;[,&lt;name&gt;[,public|private]] 
+                                  (Short form: /res)
+/win32icon:&lt;file&gt;                 Specifies a Win32 icon file (.ico) for the 
+                                  default Win32 resources.
+/win32manifest:&lt;file&gt;             The provided file is embedded in the manifest
+                                  section of the output PE.
+/win32resource:&lt;file&gt;             Specifies a Win32 resource file (.res).
 
-                                  - 產生程式碼 -
-/optimize[+|-]                    啟用最佳化。
-/removeintchecks[+|-]             移除整數檢查。預設為關閉。
-/debug[+|-]                       發出偵錯資訊。
-/debug:full                       發出完整偵錯資訊 (預設)。
-/debug:pdbonly                    發出完整偵錯資訊。
-/debug:portable                   發出跨平台偵錯資訊。
-/debug:embedded                   將跨平台偵錯資訊發出到
-                                 目標 .dll 或 .exe 中。
-/deterministic                    產生確定性組件
-                                  (包括模組版本 GUID 與時間戳記)
-/refonly                          產生參考組件取代主要輸出
-/instrument:TestCoverage          產生檢測組件，以收集
-                                  涵蓋範圍資訊
-/sourcelink:&lt;檔案&gt;                要內嵌 PDB 中的來源連結資訊。
+                                  - CODE GENERATION -
+/optimize[+|-]                    Enable optimizations.
+/removeintchecks[+|-]             Remove integer checks. Default off.
+/debug[+|-]                       Emit debugging information.
+/debug:full                       Emit full debugging information (default).
+/debug:pdbonly                    Emit full debugging information.
+/debug:portable                   Emit cross-platform debugging information.
+/debug:embedded                   Emit cross-platform debugging information into 
+                                  the target .dll or .exe.
+/deterministic                    Produce a deterministic assembly
+                                  (including module version GUID and timestamp)
+/refonly                          Produce a reference assembly in place of the main output
+/instrument:TestCoverage          Produce an assembly instrumented to collect
+                                  coverage information
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
-                                  - 錯誤與警告 -
-/nowarn                           停用所有警告。
-/nowarn:&lt;號碼清單&gt;             停用個別警告的清單。
-/warnaserror[+|-]                 將所有警告視為錯誤。
-/warnaserror[+|-]:&lt;號碼清單&gt;   將警告清單視為錯誤。
-/ruleset:&lt;檔案&gt;                   指定會停用特定診斷的規則集
-                                  檔案。
-/errorlog:&lt;檔案&gt;                  指定要記錄所有編譯器和分析器診斷的
-                                  檔案。
-/reportanalyzer                   回報其他分析器資訊，例如
-                                  執行時間。
+                                  - ERRORS AND WARNINGS -
+/nowarn                           Disable all warnings.
+/nowarn:&lt;number_list&gt;             Disable a list of individual warnings.
+/warnaserror[+|-]                 Treat all warnings as errors.
+/warnaserror[+|-]:&lt;number_list&gt;   Treat a list of warnings as errors.
+/ruleset:&lt;file&gt;                   Specify a ruleset file that disables specific
+                                  diagnostics.
+/errorlog:&lt;file&gt;                  Specify a file to log all compiler and analyzer
+                                  diagnostics.
+/reportanalyzer                   Report additional analyzer information, such as
+                                  execution time.
 
-                                  - 語言 -
-/define:&lt;符號清單&gt;             宣告全域條件式編譯
-                                  符號。symbol_list:name=value,... 
-                                  (簡短形式: /d)
-/imports:&lt;import_list&gt;            在參考的中繼資料檔中，宣告命名空間的
-                                  全域匯入。
+                                  - LANGUAGE -
+/define:&lt;symbol_list&gt;             Declare global conditional compilation 
+                                  symbol(s). symbol_list:name=value,... 
+                                  (Short form: /d)
+/imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
+                                  referenced metadata files. 
                                   import_list:namespace,...
-/langversion:&lt;號碼&gt;             指定語言版本: 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest。
-/optionexplicit[+|-]              必須明確宣告變數。
-/optioninfer[+|-]                 允許變數的類型推斷。
-/rootnamespace:&lt;字串&gt;           指定所有類型宣告的
-                                  根命名空間。
-/optionstrict[+|-]                強制採用嚴格的語意。
-/optionstrict:custom              未遵守嚴格的語意時
-                                  發出警告。
-/optioncompare:binary             指定二進位樣式字串比較。
-                                  此為預設。
-/optioncompare:text               指定文字樣式字串比較。
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `14` or `15.3`
+/optionexplicit[+|-]              Require explicit declaration of variables.
+/optioninfer[+|-]                 Allow type inference of variables.
+/rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 
+                                  declarations.
+/optionstrict[+|-]                Enforce strict language semantics.
+/optionstrict:custom              Warn when strict language semantics are not
+                                  respected.
+/optioncompare:binary             Specifies binary-style string comparisons.
+                                  This is the default.
+/optioncompare:text               Specifies text-style string comparisons.
 
-                                  - 其他 -
-/help                             顯示此使用訊息。(簡短形式: /?)
-/noconfig                         不要自動包含 VBC.RSP 檔。
-/nologo                           不顯示編譯器著作權橫幅。
-/quiet                            無訊息輸出模式。
-/verbose                          顯示詳細訊息。
-/parallel[+|-]                    並行建置。
-/version                          顯示編譯器的版本號碼並結束。
+                                  - MISCELLANEOUS -
+/help                             Display this usage message. (Short form: /?)
+/noconfig                         Do not auto-include VBC.RSP file.
+/nologo                           Do not display compiler copyright banner.
+/quiet                            Quiet output mode.
+/verbose                          Display verbose messages.
+/parallel[+|-]                    Concurrent build. 
+/version                          Display the compiler version number and exit.
 
-                                  - 進階 -
-/baseaddress:&lt;數字&gt;             程式庫或模組的基底位址
-                                  (十六進位)。
-/checksumalgorithm:&lt;alg&gt;          為計算儲存在 PDB 中的來源檔案總和檢查碼
-                                  指定演算法。支援的值為:
-                                  SHA1 (預設) 或 SHA256。
-/codepage:&lt;號碼&gt;                指定開啟來源檔案時要使用的
-                                  字碼頁。
-/delaysign[+|-]                   只使用強式名稱金鑰的公開部分，
-                                  延遲簽署組件。
-/publicsign[+|-]                  只使用強式名稱金鑰的公開
-                                  部分公開簽署組件。
-/errorreport:&lt;字串&gt;             指定如何處理內部編譯器
-                                  錯誤; 必須是 prompt、send、none 或 queue
-                                  (預設)。
-/filealign:&lt;號碼&gt;               指定用於輸出檔區段的
-                                  對齊。
-/highentropyva[+|-]               啟用高度 Entropy ASLR。
-/keycontainer:&lt;字串&gt;            指定強式名稱金鑰容器。
-/keyfile:&lt;檔案&gt;                   指定強式名稱金鑰檔。
-/libpath:&lt;路徑清單&gt;              要在其中搜尋中繼資料參考的目錄清單
-                                  (以分號分隔)。
-/main:&lt;類別&gt;                     指定包含 Sub Main 的類別或模組。
-                                  也可以是繼承自
-                                  System.Windows.Forms.Form 的類別。
-                                  (簡短形式: /m)
-/moduleassemblyname:&lt;字串&gt;      要將此模組包含為一部分的
-                                  組件名稱。
-/netcf                            以 .NET Compact Framework 為目標。
-/nostdlib                         不要參考標準程式庫
-                                  (system.dll 和 VBC.RSP 檔案)。
-/pathmap:&lt;K1&gt;=&lt;V1&gt;、&lt;K2&gt;=&lt;V2&gt;、...
-                                  為編譯器輸出的來源路徑名稱
-                                  指定對應。
-/platform:&lt;字串&gt;                限制這個程式碼可以在哪些平台執行; 
-                                  必須是 x86、x64、Itanium、arm、
-                                  AnyCPU32BitPreferred 或 anycpu (預設)。
-/preferreduilang                  指定慣用的輸出語言名稱。
-/sdkpath:&lt;路徑&gt;                   .NET Framework SDK 目錄的位置
-                                  (mscorlib.dll)。
-/subsystemversion:&lt;版本&gt;       指定輸出 PE 的子系統版本。
-                                  version:&lt;號碼&gt;[.&lt;號碼&gt;]
-/utf8output[+|-]                  以 UTF8 字元編碼發出編譯器
-                                  輸出。
-@&lt;檔案&gt;                           從文字檔插入命令列設定
-/vbruntime[+|-|*]                 使用 (或不使用) 預設 Visual Basic 執行階段
-                                  進行編譯。
-/vbruntime:&lt;檔案&gt;                 使用 &lt;檔案&gt; 中的其他 Visual Basic 執行階段
-                                  進行編譯。
+                                  - ADVANCED -
+/baseaddress:&lt;number&gt;             The base address for a library or module 
+                                  (hex).
+/checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
+                                  checksum stored in PDB. Supported values are:
+                                  SHA1 (default) or SHA256.
+/codepage:&lt;number&gt;                Specifies the codepage to use when opening 
+                                  source files.
+/delaysign[+|-]                   Delay-sign the assembly using only the public
+                                  portion of the strong name key.
+/publicsign[+|-]                  Public-sign the assembly using only the public
+                                  portion of the strong name key.
+/errorreport:&lt;string&gt;             Specifies how to handle internal compiler
+                                  errors; must be prompt, send, none, or queue
+                                  (default).
+/filealign:&lt;number&gt;               Specify the alignment used for output file 
+                                  sections.
+/highentropyva[+|-]               Enable high-entropy ASLR.
+/keycontainer:&lt;string&gt;            Specifies a strong name key container.
+/keyfile:&lt;file&gt;                   Specifies a strong name key file.
+/libpath:&lt;path_list&gt;              List of directories to search for metadata 
+                                  references. (Semi-colon delimited.)
+/main:&lt;class&gt;                     Specifies the Class or Module that contains 
+                                  Sub Main. It can also be a Class that 
+                                  inherits from System.Windows.Forms.Form. 
+                                  (Short form: /m)
+/moduleassemblyname:&lt;string&gt;      Name of the assembly which this module will 
+                                  be a part of.
+/netcf                            Target the .NET Compact Framework.
+/nostdlib                         Do not reference standard libraries 
+                                  (system.dll and VBC.RSP file).
+/pathmap:&lt;K1&gt;=&lt;V1&gt;,&lt;K2&gt;=&lt;V2&gt;,...
+                                  Specify a mapping for source path names output by
+                                  the compiler.
+/platform:&lt;string&gt;                Limit which platforms this code can run on; 
+                                  must be x86, x64, Itanium, arm,
+                                  AnyCPU32BitPreferred or anycpu (default).
+/preferreduilang                  Specify the preferred output language name.
+/sdkpath:&lt;path&gt;                   Location of the .NET Framework SDK directory
+                                  (mscorlib.dll).
+/subsystemversion:&lt;version&gt;       Specify subsystem version of the output PE. 
+                                  version:&lt;number&gt;[.&lt;number&gt;]
+/utf8output[+|-]                  Emit compiler output in UTF8 character 
+                                  encoding.
+@&lt;file&gt;                           Insert command-line settings from a text file
+/vbruntime[+|-|*]                 Compile with/without the default Visual Basic
+                                  runtime.
+/vbruntime:&lt;file&gt;                 Compile with the alternate Visual Basic 
+                                  runtime in &lt;file&gt;.
 </value>
   </data>
   <data name="ERR_ReturnFromNonGenericTaskAsync" xml:space="preserve">
@@ -4493,7 +4516,7 @@
     <value>'{0}' 無法覆寫 '{1}'，因為其類型參數條件約束不同。</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>必須有具名引數。</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_CircularEvaluation1" xml:space="preserve">
     <value>常數 '{0}' 無法相依其本身的值。</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.cs.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.cs.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>třída</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>Kopie modulu se nedá použít k vytvoření metadat sestavení.</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>Názvem prvku řazené kolekce členů nemůže být prázdný řetězec.</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>Vložené texty se podporují jenom při generování souboru PDB typu Portable.</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>Neplatný druh výstupu pro odeslání Očekávalo se DynamicallyLinkedLibrary.</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.de.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.de.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>Klasse</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>Modulkopie kann nicht zum Erstellen von Assembly-Metadaten verwendet werden.</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>Ein Tupelelement darf kein leerer String sein.</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>Eingebettete Texte werden nur unterstützt, wenn portable PDB-Dateien ausgegeben werden.</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>Die Übermittlung weist einen ungültigen Ausgabetyp auf. DynamicallyLinkedLibrary erwartet.</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.es.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.es.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>clase</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>No se puede usar una copia de módulo para crear metadatos de ensamblado.</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>El nombre del elemento de tupla no puede ser una cadena vacía.</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>Solo se admiten textos insertados cuando se emite un archivo PDB portátil.</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>Tipo de salida no válida para el envío. DynamicallyLinkedLibrary esperado.</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.fr.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.fr.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>classe</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>Impossible d'utiliser le module de copie pour créer des métadonnées d'assembly.</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>Le nom d'élément tuple ne peut pas être une chaîne vide.</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>Les textes incorporés sont uniquement pris en charge durant l'émission d'un fichier PDB portable.</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>Type de sortie non valide pour la soumission. DynamicallyLinkedLibrary attendu.</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.it.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.it.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>classe</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>Non è possibile usare la copia del modulo per creare i metadati di un assembly.</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>Il nome di elemento di tupla non può essere una stringa vuota.</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>I testi incorporati sono supportati solo quando si crea il PDB portatile.</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>Il tipo di output per l'invio non è valido. È previsto DynamicallyLinkedLibrary.</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.ja.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.ja.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>クラス</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>モジュールのコピーは、アセンブリ メタデータの作成には使用できません。</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>タプル要素名を空の文字列にすることはできません。</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>埋め込みのテキストは、ポータブル PDB の生成時にのみサポートされます。</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>送信の出力の種類が無効です。DynamicallyLinkedLibrary が必要です。</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.ko.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.ko.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>클래스</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>모듈 복사본은 어셈블리 메타데이터를 만드는 데 사용할 수 없습니다.</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>튜플 요소 이름은 빈 문자열일 수 없습니다.</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>이식 가능한 PDB를 내보낼 때만 포함된 텍스트가 지원됩니다.</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>제출에 대해 잘못된 출력 종류입니다. DynamicallyLinkedLibrary가 필요합니다.</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.pl.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.pl.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>klasa</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>Nie można użyć kopii modułu do utworzenia metadanych zestawu.</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>Nazwa elementu krotki nie może być pustym ciągiem.</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>Osadzony tekst jest obsługiwany tylko w przypadku emitowania przenośnego pliku PDB.</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>Nieprawidłowy rodzaj wyjścia przesłanego elementu. Oczekiwano elementu DynamicallyLinkedLibrary.</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.pt-BR.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.pt-BR.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>classe</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>Cópia de módulo não pode ser usada para criar metadados do assembly.</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>O nome de elemento de tupla não pode ser uma cadeia de caracteres vazia.</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>Só há suporte para textos inseridos ao emitir um PDB Portátil.</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>Tipo de saída inválido para envio. DynamicallyLinkedLibrary esperado.</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.ru.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.ru.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>класс</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>Копию модуля нельзя использовать для создания метаданных сборки.</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>Имя элемента кортежа не может быть пустой строкой.</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>Внедренный текст поддерживается только при создании файлов Portable PDB.</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>Недопустимый тип выходных данных для сообщения. Ожидался DynamicallyLinkedLibrary.</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.tr.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.tr.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>class</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>Derleme meta verileri oluşturmak için modül kopyası kullanılamaz.</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>Demet öğesi adı boş bir dize olamaz.</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>Gömülü metinler yalnızca Taşınabilir PDB gösterilirken desteklenir.</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>Gönderim için geçersiz çıkış türü. DynamicallyLinkedLibrary bekleniyor.</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.zh-Hans.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.zh-Hans.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>类</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>模块复制不能用于创建程序集元数据。</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>元组元素名称不能为空字符串。</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>仅在发出可移植 PDB 时支持嵌入的文本。</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>无效的提交输出类型。预期为 DynamicallyLinkedLibrary。</value>

--- a/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.zh-Hant.resx
+++ b/src/Microsoft.CodeAnalysis/Microsoft.CodeAnalysis.CodeAnalysisResources.zh-Hant.resx
@@ -178,6 +178,9 @@
   <data name="Class1" xml:space="preserve">
     <value>類別</value>
   </data>
+  <data name="EmbeddedTextsRequirePdb" xml:space="preserve">
+    <value>Embedded texts are only supported when emitting a PDB.</value>
+  </data>
   <data name="ModuleCopyCannotBeUsedToCreateAssemblyMetadata" xml:space="preserve">
     <value>不可使用模組複本建立組件中繼資料。</value>
   </data>
@@ -497,9 +500,6 @@
   </data>
   <data name="TupleElementNameEmpty" xml:space="preserve">
     <value>元組元素名稱不可為空字串。</value>
-  </data>
-  <data name="EmbeddedTextsRequirePortablePdb" xml:space="preserve">
-    <value>只在發出可攜式 PDB 時才支援內嵌的文字。</value>
   </data>
   <data name="InvalidOutputKindForSubmission" xml:space="preserve">
     <value>提交的輸出種類無效。必須是 DynamicallyLinkedLibrary。</value>


### PR DESCRIPTION
Bump version number to 2.6
Use specific build number in UpdateResources.proj

***NOTE***: New and modified strings here are in English because the translations have  not yet been handed back yet. This accurately matches the most up-to-date 15.5 closed-source satellites that are currently available. The new translations will be picked up in a subsequent update.